### PR TITLE
Cache connections

### DIFF
--- a/rider-cdi/src/main/java/com/github/database/rider/cdi/DataSetProcessor.java
+++ b/rider-cdi/src/main/java/com/github/database/rider/cdi/DataSetProcessor.java
@@ -125,7 +125,7 @@ public class DataSetProcessor {
             }
             exportConfig.outputFileName(outputName);
             try {
-                DataSetExporter.getInstance().export(dataSetExecutor.getDBUnitConnection(),exportConfig);
+                DataSetExporter.getInstance().export(dataSetExecutor.getRiderDataSource().getDBUnitConnection(),exportConfig);
             } catch (Exception e) {
                 log.warn("Could not export dataset after method " + method.getName(), e);
             }

--- a/rider-cdi/src/test/java/com/github/database/rider/cdi/BeforeAndAfterTest.java
+++ b/rider-cdi/src/test/java/com/github/database/rider/cdi/BeforeAndAfterTest.java
@@ -31,6 +31,8 @@ public class BeforeAndAfterTest {
     @Before
     public void init() {
         em.getTransaction().begin();
+        em.createNativeQuery("DELETE FROM FOLLOWER").executeUpdate();
+        em.createNativeQuery("DELETE FROM TWEET").executeUpdate();
         em.createNativeQuery("DELETE FROM USER").executeUpdate();//delete users inserted in other tests
         for (int i=0;i<6;i++ ) {
             User u = new User();

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
@@ -1,10 +1,10 @@
 package com.github.database.rider.core.api.dataset;
 
+import com.github.database.rider.core.configuration.ConnectionConfig;
 import com.github.database.rider.core.configuration.DBUnitConfig;
-import com.github.database.rider.core.api.connection.ConnectionHolder;
 import com.github.database.rider.core.configuration.DataSetConfig;
+import com.github.database.rider.core.connection.RiderDataSource;
 import org.dbunit.DatabaseUnitException;
-import org.dbunit.database.DatabaseConnection;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.IDataSet;
 
@@ -26,9 +26,7 @@ public interface DataSetExecutor{
 
     IDataSet loadDataSets(String[] datasets) throws DataSetException, IOException;
 
-    ConnectionHolder getConnectionHolder();
-
-    void setConnectionHolder(ConnectionHolder connectionHolder);
+    void initConnectionFromConfig(ConnectionConfig connectionConfig) throws SQLException;
 
     void clearDatabase(DataSetConfig dataset) throws SQLException;
 
@@ -51,7 +49,7 @@ public interface DataSetExecutor{
 
     DBUnitConfig getDBUnitConfig();
 
-    DatabaseConnection getDBUnitConnection() throws DatabaseUnitException, SQLException;
+    RiderDataSource getRiderDataSource() throws DatabaseUnitException, SQLException;
 
     void enableConstraints() throws SQLException ;
 

--- a/rider-core/src/main/java/com/github/database/rider/core/connection/ConnectionHolderImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/connection/ConnectionHolderImpl.java
@@ -19,9 +19,4 @@ public class ConnectionHolderImpl implements ConnectionHolder {
     public Connection getConnection() {
         return connection;
     }
-
-    public void setConnection(Connection connection) {
-        this.connection = connection;
-    }
-
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
@@ -1,0 +1,112 @@
+package com.github.database.rider.core.connection;
+
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.util.DriverUtils;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.DatabaseConfig;
+import org.dbunit.database.DatabaseConnection;
+import org.dbunit.ext.h2.H2DataTypeFactory;
+import org.dbunit.ext.hsqldb.HsqldbDataTypeFactory;
+import org.dbunit.ext.mysql.MySqlDataTypeFactory;
+import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class RiderDataSource {
+
+    public enum DBType { HSQLDB, H2, MYSQL, ORACLE, POSTGRESQL, UNKNOWN }
+
+    private final ConnectionHolder connectionHolder;
+    private final DBUnitConfig dbUnitConfig;
+    private Connection connection;
+    private DatabaseConnection dbUnitConnection;
+    private DBType dbType;
+
+    public RiderDataSource(ConnectionHolder connectionHolder, DBUnitConfig dbUnitConfig) throws SQLException {
+        this.connectionHolder = connectionHolder;
+        this.dbUnitConfig = dbUnitConfig;
+        init();
+    }
+
+    public Connection getConnection() throws SQLException {
+        if (!dbUnitConfig.isCacheConnection() || connection == null || connection.isClosed()) {
+            connection = connectionHolder.getConnection();
+        }
+
+        return connection;
+    }
+
+    public DatabaseConnection getDBUnitConnection() throws SQLException {
+        if (!dbUnitConfig.isCacheConnection()) {
+            initDBUnitConnection();
+        }
+
+        return dbUnitConnection;
+    }
+
+    public DBType getDBType() {
+        return dbType;
+    }
+
+    private void init() throws SQLException {
+        Connection conn = getConnection();
+        if (conn != null) {
+            dbType = resolveDBType(DriverUtils.getDriverName(conn));
+            initDBUnitConnection();
+        }
+    }
+
+    private void initDBUnitConnection() throws SQLException {
+        try {
+            dbUnitConnection = new DatabaseConnection(getConnection());
+            configDatabaseProperties();
+        } catch (DatabaseUnitException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    private void configDatabaseProperties() throws SQLException {
+        DatabaseConfig config = dbUnitConnection.getConfig();
+        for (Map.Entry<String, Object> p : dbUnitConfig.getProperties().entrySet()) {
+            config.setProperty(DatabaseConfig.findByShortName(p.getKey()).getProperty(), p.getValue());
+        }
+
+        switch (dbType) {
+            case HSQLDB:
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new HsqldbDataTypeFactory());
+                break;
+            case H2:
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new H2DataTypeFactory());
+                break;
+            case MYSQL:
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MySqlDataTypeFactory());
+                break;
+            case POSTGRESQL:
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
+                break;
+            case ORACLE:
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+                break;
+        }
+    }
+
+    private DBType resolveDBType(String driverName) throws SQLException {
+        if (DriverUtils.isHsql(driverName)) {
+            return DBType.HSQLDB;
+        } else if (DriverUtils.isH2(driverName)) {
+            return DBType.H2;
+        } else if (DriverUtils.isMysql(driverName)) {
+            return DBType.MYSQL;
+        } else if (DriverUtils.isPostgre(driverName)) {
+            return DBType.POSTGRESQL;
+        } else if (DriverUtils.isOracle(driverName)) {
+            return DBType.ORACLE;
+        } else {
+            return DBType.UNKNOWN;
+        }
+    }
+}

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
@@ -118,7 +118,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
                     EntityManagerProvider.em().getTransaction().begin();
                 }
             } else{
-                Connection connection = executor.getConnectionHolder().getConnection();
+                Connection connection = executor.getRiderDataSource().getConnection();
                 connection.setAutoCommit(false);
             }
         }
@@ -148,7 +148,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
             }
             exportConfig.outputFileName(outputName);
             try {
-                DataSetExporter.getInstance().export(dataSetExecutor.getDBUnitConnection(),exportConfig);
+                DataSetExporter.getInstance().export(dataSetExecutor.getRiderDataSource().getDBUnitConnection(),exportConfig);
             } catch (Exception e) {
             	log.warn("Could not export dataset after method "+method.getName(),e);
             }
@@ -186,7 +186,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
                                     EntityManagerProvider.tx().commit();
                                 }
                             } else {
-                                Connection connection = executor.getConnectionHolder().getConnection();
+                                Connection connection = executor.getRiderDataSource().getConnection();
                                 connection.commit();
                                 connection.setAutoCommit(false);
                             }
@@ -194,7 +194,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
                             if(EntityManagerProvider.isEntityManagerActive()){
                                 EntityManagerProvider.tx().rollback();
                             } else{
-                                Connection connection = executor.getConnectionHolder().getConnection();
+                                Connection connection = executor.getRiderDataSource().getConnection();
                                 connection.setAutoCommit(false);
                                 connection.setReadOnly(true);
                             }


### PR DESCRIPTION
Database-rider opens multiple connections if connection pool was used and DBUnitRule initialized like
```
@Rule
public DBUnitRule dbUnitRule = DBUnitRule.instance(() -> datasource.getConnection());
```

This can lead to a freezing tests when all connections from the pool obtained. It can also break the functionality of disabling constraints