### PR TITLE
Transactional interceptor doesn't close transaction when test falls down by assert

### DIFF
--- a/rider-cdi/src/main/java/com/github/database/rider/cdi/DBUnitInterceptorImpl.java
+++ b/rider-cdi/src/main/java/com/github/database/rider/cdi/DBUnitInterceptorImpl.java
@@ -75,13 +75,11 @@ public class DBUnitInterceptorImpl implements Serializable {
                 if(expectedDataSet != null){
                     dataSetProcessor.compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).disableConstraints(true),expectedDataSet.ignoreCols());
                 }
-
-            }catch (Exception e){
+            } finally {
                 if(isTransactionalTest && em.getTransaction().isActive()){
                     em.getTransaction().rollback();
                 }
-                throw e;
-            } finally {
+
                 int openConnectionsAfter = 0;
                 if(leakHunter != null){
                     openConnectionsAfter = leakHunter.openConnections();


### PR DESCRIPTION
When we have many tests in one module and one of them falls then all remained tests can fall down because transaction is not closed.
In such case catch section is not executed because assert checking throws instance of Throwable (not Exception).