### PR TITLE
Extract test runner logic in junit agnostic class

### DIFF
--- a/rider-cdi/src/main/java/com/github/database/rider/cdi/DataSetProcessor.java
+++ b/rider-cdi/src/main/java/com/github/database/rider/cdi/DataSetProcessor.java
@@ -147,4 +147,8 @@ public class DataSetProcessor {
             log.warn("Could not enable constraints.", e);
         }
     }
+
+    public DataSetExecutor getDataSetExecutor() {
+        return dataSetExecutor;
+    }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/AbstractRiderTestContext.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/AbstractRiderTestContext.java
@@ -1,0 +1,30 @@
+package com.github.database.rider.core;
+
+import com.github.database.rider.core.api.dataset.DataSetExecutor;
+
+import java.lang.annotation.Annotation;
+
+public abstract class AbstractRiderTestContext implements RiderTestContext {
+
+    protected final DataSetExecutor executor;
+
+    public AbstractRiderTestContext(DataSetExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public DataSetExecutor getDataSetExecutor() {
+        return executor;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> clazz) {
+        T annotation = getMethodAnnotation(clazz);
+
+        if (annotation == null) {
+            annotation = getClassAnnotation(clazz);
+        }
+
+        return annotation;
+    }
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/DBUnitRule.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/DBUnitRule.java
@@ -1,270 +1,100 @@
 package com.github.database.rider.core;
 
-import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.connection.ConnectionHolder;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.DataSetExecutor;
-import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.core.api.exporter.DataSetExportConfig;
-import com.github.database.rider.core.api.exporter.ExportDataSet;
 import com.github.database.rider.core.api.leak.LeakHunter;
-import com.github.database.rider.core.configuration.ConnectionConfig;
 import com.github.database.rider.core.configuration.DBUnitConfig;
-import com.github.database.rider.core.configuration.DataSetConfig;
 import com.github.database.rider.core.connection.ConnectionHolderImpl;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
-import com.github.database.rider.core.exporter.DataSetExporter;
-import com.github.database.rider.core.leak.LeakHunterException;
 import com.github.database.rider.core.leak.LeakHunterFactory;
-import org.dbunit.DatabaseUnitException;
-import org.dbunit.assertion.DbUnitAssert;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
-import java.sql.SQLException;
-
-import static com.github.database.rider.core.util.EntityManagerProvider.em;
-import static com.github.database.rider.core.util.EntityManagerProvider.isEntityManagerActive;
 
 /**
  * Created by rafael-pestano on 22/07/2015.
  */
 public class DBUnitRule implements TestRule {
 
-
-    private static final Logger logger = LoggerFactory.getLogger(DbUnitAssert.class);
-
-
-    private String currentMethod;
-
     private DataSetExecutor executor;
 
     private DBUnitRule() {
     }
 
-    public final static DBUnitRule instance() {
-        return instance(new ConnectionHolderImpl(null));
-    }
-
-    public final static DBUnitRule instance(Connection connection) {
-        return instance(new ConnectionHolderImpl(connection));
-    }
-
-    public final static DBUnitRule instance(String executorName, Connection connection) {
-        return instance(executorName, new ConnectionHolderImpl(connection));
-    }
-
-    public final static DBUnitRule instance(ConnectionHolder connectionHolder) {
-        return instance(DataSetExecutorImpl.DEFAULT_EXECUTOR_ID, connectionHolder);
-    }
-
-    public final static DBUnitRule instance(String executorName, ConnectionHolder connectionHolder) {
+    public static DBUnitRule instance() {
         DBUnitRule instance = new DBUnitRule();
-        instance.init(executorName, connectionHolder);
+        instance.executor = DataSetExecutorImpl.instance(DataSetExecutorImpl.DEFAULT_EXECUTOR_ID, null);
+
         return instance;
     }
 
+    public static DBUnitRule instance(Connection connection) {
+        return instance(new ConnectionHolderImpl(connection));
+    }
+
+    public static DBUnitRule instance(String executorName, Connection connection) {
+        return instance(executorName, new ConnectionHolderImpl(connection));
+    }
+
+    public static DBUnitRule instance(ConnectionHolder connectionHolder) {
+        return instance(DataSetExecutorImpl.DEFAULT_EXECUTOR_ID, connectionHolder);
+    }
+
+    public static DBUnitRule instance(String executorName, ConnectionHolder connectionHolder) {
+        DBUnitRule instance = new DBUnitRule();
+        instance.executor = DataSetExecutorImpl.instance(executorName, connectionHolder);
+
+        return instance;
+    }
 
     @Override
     public Statement apply(final Statement statement, final Description description) {
+        DataSet dataSet = description.getAnnotation(DataSet.class);
+        if (dataSet == null) {
+            dataSet = description.getTestClass().getAnnotation(DataSet.class);
+        }
+
+        if (dataSet != null && !"".equals(dataSet.executorId().trim())) {
+            executor = DataSetExecutorImpl.getExecutorById(dataSet.executorId());
+        }
 
         return new Statement() {
 
             @Override
             public void evaluate() throws Throwable {
-                DBUnitConfig dbUnitConfig = resolveDBUnitConfig(description);
-                currentMethod = description.getMethodName();
-                DataSet dataSet = resolveDataSet(description);
-                if (dataSet != null) {
-                    final DataSetConfig dataSetConfig = new DataSetConfig().from(dataSet);
-                    final String datasetExecutorId = dataSetConfig.getExecutorId();
-                    LeakHunter leakHunter = null;
-                    boolean executorNameIsProvided = datasetExecutorId != null && !"".equals(datasetExecutorId.trim());
-                    if (executorNameIsProvided) {
-                        executor = DataSetExecutorImpl.getExecutorById(datasetExecutorId);
-                    }
-                    try {
-                        if (executor.getRiderDataSource().getConnection() == null) {
-                            initConnectionFromConfig(executor, dbUnitConfig);
-                        }
-                        executor.setDBUnitConfig(dbUnitConfig);
-                        executor.createDataSet(dataSetConfig);
-                    } catch (final Exception e) {
-                        throw new RuntimeException(String.format("Could not create dataset for test '%s'.", description.getMethodName()), e);
-                    }
-                    boolean isTransactional = false;
-                    try {
-                        isTransactional = dataSetConfig.isTransactional();
-                        if (isTransactional) {
-                            if (isEntityManagerActive()) {
-                                em().getTransaction().begin();
-                            } else {
-                                Connection connection = executor.getRiderDataSource().getConnection();
-                                connection.setAutoCommit(false);
-                            }
-                        }
-                        boolean leakHunterActivated = dbUnitConfig.isLeakHunter();
-                        int openConnectionsBefore = 0;
-                        if (leakHunterActivated) {
-                            leakHunter = LeakHunterFactory.from(executor.getRiderDataSource().getConnection());
-                            openConnectionsBefore = leakHunter.openConnections();
-                        }
-                        statement.evaluate();
+                RiderTestContext riderTestContext = new JUnit4RiderTestContext(executor, description);
+                RiderRunner riderRunner = new RiderRunner();
+                riderRunner.setup(riderTestContext);
 
-                        if (leakHunterActivated) {
-                            int openConnectionsAfter = leakHunter.openConnections();
-                            if (openConnectionsAfter > openConnectionsBefore) {
-                                throw new LeakHunterException(currentMethod, openConnectionsAfter - openConnectionsBefore);
-                            }
-                        }
+                DBUnitConfig dbUnitConfig = riderTestContext.getDataSetExecutor().getDBUnitConfig();
 
-                        if (isTransactional) {
-                            if (isEntityManagerActive() && em().getTransaction().isActive()) {
-                                em().getTransaction().commit();
-                            } else {
-                                Connection connection = executor.getRiderDataSource().getConnection();
-                                connection.commit();
-                                connection.setAutoCommit(false);
-                            }
-                        }
-                        performDataSetComparison(description);
-                    } finally {
-                        if (isTransactional) {
-                            if (isEntityManagerActive() && em().getTransaction().isActive()) {
-                                em().getTransaction().rollback();
-                            } else {
-                                Connection connection = executor.getRiderDataSource().getConnection();
-                                connection.rollback();
-                            }
-                        }
-                        exportDataSet(executor, description);
-                        if (dataSetConfig != null && dataSetConfig.getExecuteStatementsAfter() != null && dataSetConfig.getExecuteStatementsAfter().length > 0) {
-                            try {
-                                executor.executeStatements(dataSetConfig.getExecuteStatementsAfter());
-                            } catch (Exception e) {
-                                logger.error(currentMethod + "() - Could not execute statements after:" + e.getMessage(), e);
-                            }
-                        }//end execute statements
-                        if (dataSetConfig != null && dataSetConfig.getExecuteScriptsAfter() != null && dataSetConfig.getExecuteScriptsAfter().length > 0) {
-                            try {
-                                for (int i = 0; i < dataSetConfig.getExecuteScriptsAfter().length; i++) {
-                                    executor.executeScript(dataSetConfig.getExecuteScriptsAfter()[i]);
-                                }
-                            } catch (Exception e) {
-                                if (e instanceof DatabaseUnitException) {
-                                    throw e;
-                                }
-                                logger.error(currentMethod + "() - Could not execute scriptsAfter:" + e.getMessage(), e);
-                            }
-                        }//end execute scripts
-
-                        if (dataSetConfig.isCleanAfter()) {
-                            executor.clearDatabase(dataSetConfig);
-                        }
-                        try {
-                            executor.enableConstraints();
-                        } catch (SQLException e) {
-                            logger.warn("Could not enable constraints.", e);
-                        }
-                    }//finally
-
-                }  //no dataset provided, only export and evaluate expected dataset
-                else {
-                    if (executor.getRiderDataSource().getConnection() == null) {
-                        initConnectionFromConfig(executor, dbUnitConfig);
-                    }
-                    exportDataSet(executor, description);
-                    statement.evaluate();
-                    performDataSetComparison(description);
-                }
-
-            }
-
-            private void initConnectionFromConfig(DataSetExecutor executor, DBUnitConfig dbUnitConfig) {
-                ConnectionConfig connectionConfig = dbUnitConfig.getConnectionConfig();
-                if ("".equals(connectionConfig.getUrl()) || "".equals(connectionConfig.getUser())) {
-                    throw new RuntimeException(String.format("Could not create JDBC connection for method %s, provide a connection at test level or via configuration, see documentation here: https://github.com/database-rider/database-rider#jdbc-connection", currentMethod));
-                }
                 try {
-                    executor.initConnectionFromConfig(connectionConfig);
-                } catch (Exception e) {
-                    logger.error("Could not create JDBC connection for method " + currentMethod, e);
+                    riderRunner.runBeforeTest(riderTestContext);
+
+                    LeakHunter leakHunter = null;
+                    if (dbUnitConfig.isLeakHunter()) {
+                        leakHunter = LeakHunterFactory.from(riderTestContext.getDataSetExecutor().getRiderDataSource(), riderTestContext.getMethodName());
+                        leakHunter.measureConnectionsBeforeExecution();
+                    }
+
+                    statement.evaluate();
+
+                    if (dbUnitConfig.isLeakHunter() && leakHunter != null) {
+                        leakHunter.checkConnectionsAfterExecution();
+                    }
+
+                    riderRunner.runAfterTest(riderTestContext);
+                } finally {
+                    riderRunner.teardown(riderTestContext);
                 }
             }
-
-
         };
-    }
-
-    private void exportDataSet(DataSetExecutor executor, Description description) {
-        ExportDataSet exportDataSet = resolveExportDataSet(description);
-        if (exportDataSet != null) {
-            DataSetExportConfig exportConfig = DataSetExportConfig.from(exportDataSet);
-            String outputName = exportConfig.getOutputFileName();
-            if (outputName == null || "".equals(outputName.trim())) {
-                outputName = description.getMethodName().toLowerCase() + "." + exportConfig.getDataSetFormat().name().toLowerCase();
-            }
-            exportConfig.outputFileName(outputName);
-            try {
-                DataSetExporter.getInstance().export(executor.getRiderDataSource().getDBUnitConnection(), exportConfig);
-            } catch (Exception e) {
-                logger.error("Could not export dataset after method " + description.getMethodName(), e);
-            }
-        }
-    }
-
-    private ExportDataSet resolveExportDataSet(Description description) {
-        ExportDataSet exportDataSet = description.getAnnotation(ExportDataSet.class);
-        if (exportDataSet == null) {
-            exportDataSet = description.getTestClass().getAnnotation(ExportDataSet.class);
-        }
-        return exportDataSet;
-    }
-
-    private DataSet resolveDataSet(Description description) {
-        DataSet dataSet = description.getAnnotation(DataSet.class);
-        if (dataSet == null) {
-            dataSet = description.getTestClass().getAnnotation(DataSet.class);
-        }
-        return dataSet;
-    }
-
-    private DBUnitConfig resolveDBUnitConfig(Description description) {
-        DBUnit dbUnitConfig = description.getAnnotation(DBUnit.class);
-        if (dbUnitConfig == null) {
-            dbUnitConfig = description.getTestClass().getAnnotation(DBUnit.class);
-        }
-
-        if (dbUnitConfig != null) {
-            return DBUnitConfig.from(dbUnitConfig);
-        } else {
-            return DBUnitConfig.fromGlobalConfig();
-        }
-    }
-
-    private void performDataSetComparison(Description description) throws DatabaseUnitException {
-        ExpectedDataSet expectedDataSet = description.getAnnotation(ExpectedDataSet.class);
-        if (expectedDataSet == null) {
-            //try to infer from class level annotation
-            expectedDataSet = description.getTestClass().getAnnotation(ExpectedDataSet.class);
-        }
-        if (expectedDataSet != null) {
-            executor.compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).disableConstraints(true), expectedDataSet.ignoreCols());
-        }
-    }
-
-    private void init(String name, ConnectionHolder connectionHolder) {
-        executor = DataSetExecutorImpl.instance(name, connectionHolder);
-
     }
 
     public DataSetExecutor getDataSetExecutor() {
         return executor;
     }
-
-
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/JUnit4RiderTestContext.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/JUnit4RiderTestContext.java
@@ -1,0 +1,35 @@
+package com.github.database.rider.core;
+
+import com.github.database.rider.core.api.dataset.DataSetExecutor;
+import org.junit.runner.Description;
+
+import java.lang.annotation.Annotation;
+
+public class JUnit4RiderTestContext extends AbstractRiderTestContext {
+
+    private final Description description;
+
+    public JUnit4RiderTestContext(DataSetExecutor executor, Description description) {
+        super(executor);
+        this.description = description;
+    }
+
+    @Override
+    public String getMethodName() {
+        return description.getMethodName();
+    }
+
+    @Override
+    public <T extends Annotation> T getMethodAnnotation(Class<T> clazz) {
+        if (description.isTest()) {
+            return description.getAnnotation(clazz);
+        }
+
+        return null;
+    }
+
+    @Override
+    public <T extends Annotation> T getClassAnnotation(Class<T> clazz) {
+        return description.getTestClass().getAnnotation(clazz);
+    }
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
@@ -1,0 +1,164 @@
+package com.github.database.rider.core;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.DataSetExecutor;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.core.api.exporter.DataSetExportConfig;
+import com.github.database.rider.core.api.exporter.ExportDataSet;
+import com.github.database.rider.core.configuration.ConnectionConfig;
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.configuration.DataSetConfig;
+import com.github.database.rider.core.exporter.DataSetExporter;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.assertion.DbUnitAssert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static com.github.database.rider.core.util.EntityManagerProvider.em;
+import static com.github.database.rider.core.util.EntityManagerProvider.isEntityManagerActive;
+
+public class RiderRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(DbUnitAssert.class);
+
+    public void setup(RiderTestContext riderTestContext) throws SQLException {
+        DBUnitConfig dbUnitConfig = resolveDBUnitConfig(riderTestContext);
+        DataSetExecutor executor = riderTestContext.getDataSetExecutor();
+        executor.setDBUnitConfig(dbUnitConfig);
+        if (executor.getRiderDataSource().getConnection() == null) {
+            ConnectionConfig connectionConfig = executor.getDBUnitConfig().getConnectionConfig();
+            executor.initConnectionFromConfig(connectionConfig);
+        }
+    }
+
+    public void runBeforeTest(RiderTestContext riderTestContext) throws SQLException {
+        DataSetExecutor executor = riderTestContext.getDataSetExecutor();
+
+        DataSet dataSet = riderTestContext.getAnnotation(DataSet.class);
+
+        if (dataSet != null) {
+            DataSetConfig dataSetConfig = new DataSetConfig().from(dataSet);
+            try {
+                executor.createDataSet(dataSetConfig);
+            } catch (Exception e) {
+                throw new RuntimeException(String.format("Could not create dataset for test '%s'.", riderTestContext.getMethodName()), e);
+            }
+
+            if (dataSetConfig.isTransactional()) {
+                if (isEntityManagerActive()) {
+                    em().getTransaction().begin();
+                } else {
+                    Connection connection = executor.getRiderDataSource().getConnection();
+                    connection.setAutoCommit(false);
+                }
+            }
+        }
+    }
+
+    public void runAfterTest(RiderTestContext riderTestContext) throws SQLException, DatabaseUnitException {
+        DataSetExecutor executor = riderTestContext.getDataSetExecutor();
+        DataSet dataSet = riderTestContext.getAnnotation(DataSet.class);
+
+        if (dataSet != null) {
+            DataSetConfig dataSetConfig = new DataSetConfig().from(dataSet);
+
+            if (dataSetConfig.isTransactional()) {
+                if (isEntityManagerActive() && em().getTransaction().isActive()) {
+                    em().getTransaction().commit();
+                } else {
+                    Connection connection = executor.getRiderDataSource().getConnection();
+                    connection.commit();
+                    connection.setAutoCommit(false);
+                }
+            }
+        }
+
+        exportDataSet(riderTestContext);
+        performDataSetComparison(riderTestContext);
+    }
+
+    public void teardown(RiderTestContext riderTestContext) throws SQLException {
+        String currentMethod = riderTestContext.getMethodName();
+        DataSetExecutor executor = riderTestContext.getDataSetExecutor();
+        DataSet dataSet = riderTestContext.getAnnotation(DataSet.class);
+
+        if (dataSet != null) {
+            DataSetConfig dataSetConfig = new DataSetConfig().from(dataSet);
+
+            if (dataSetConfig.isTransactional()) {
+                if (isEntityManagerActive() && em().getTransaction().isActive()) {
+                    em().getTransaction().rollback();
+                } else {
+                    Connection connection = executor.getRiderDataSource().getConnection();
+                    connection.rollback();
+                }
+            }
+
+            if (dataSetConfig.getExecuteStatementsAfter() != null && dataSetConfig.getExecuteStatementsAfter().length > 0) {
+                try {
+                    executor.executeStatements(dataSetConfig.getExecuteStatementsAfter());
+                } catch (Exception e) {
+                    logger.error(currentMethod + "() - Could not execute statements after:" + e.getMessage(), e);
+                }
+            }
+            if (dataSetConfig.getExecuteScriptsAfter() != null && dataSetConfig.getExecuteScriptsAfter().length > 0) {
+                try {
+                    for (String scriptPath : dataSetConfig.getExecuteScriptsAfter()) {
+                        executor.executeScript(scriptPath);
+                    }
+                } catch (Exception e) {
+                    logger.error(currentMethod + "() - Could not execute scriptsAfter:" + e.getMessage(), e);
+                }
+            }
+
+            if (dataSetConfig.isCleanAfter()) {
+                executor.clearDatabase(dataSetConfig);
+            }
+
+            try {
+                executor.enableConstraints();
+            } catch (SQLException e) {
+                logger.warn("Could not enable constraints.", e);
+            }
+        }
+    }
+
+    private void exportDataSet(RiderTestContext riderTestContext) {
+        ExportDataSet exportDataSet = riderTestContext.getAnnotation(ExportDataSet.class);
+        if (exportDataSet != null) {
+            DataSetExportConfig exportConfig = DataSetExportConfig.from(exportDataSet);
+            String outputName = exportConfig.getOutputFileName();
+            if (outputName == null || "".equals(outputName.trim())) {
+                outputName = riderTestContext.getMethodName().toLowerCase() + "." + exportConfig.getDataSetFormat().name().toLowerCase();
+            }
+            exportConfig.outputFileName(outputName);
+            try {
+                DataSetExporter.getInstance().export(riderTestContext.getDataSetExecutor().getRiderDataSource().getDBUnitConnection(), exportConfig);
+            } catch (Exception e) {
+                logger.error("Could not export dataset after method " + riderTestContext.getMethodName(), e);
+            }
+        }
+    }
+
+    private DBUnitConfig resolveDBUnitConfig(RiderTestContext riderTestContext) {
+        DBUnit dbUnitConfig = riderTestContext.getAnnotation(DBUnit.class);
+
+        if (dbUnitConfig != null) {
+            return DBUnitConfig.from(dbUnitConfig);
+        } else {
+            return DBUnitConfig.fromGlobalConfig();
+        }
+    }
+
+    private void performDataSetComparison(RiderTestContext riderTestContext) throws DatabaseUnitException {
+        ExpectedDataSet expectedDataSet = riderTestContext.getAnnotation(ExpectedDataSet.class);
+
+        if (expectedDataSet != null) {
+            riderTestContext.getDataSetExecutor().compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).disableConstraints(true), expectedDataSet.ignoreCols());
+        }
+    }
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/RiderTestContext.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/RiderTestContext.java
@@ -1,0 +1,14 @@
+package com.github.database.rider.core;
+
+import com.github.database.rider.core.api.dataset.DataSetExecutor;
+
+import java.lang.annotation.Annotation;
+
+public interface RiderTestContext {
+
+    DataSetExecutor getDataSetExecutor();
+    String getMethodName();
+    <T extends Annotation> T getAnnotation(Class<T> clazz);
+    <T extends Annotation> T getMethodAnnotation(Class<T> clazz);
+    <T extends Annotation> T getClassAnnotation(Class<T> clazz);
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
@@ -26,7 +26,7 @@ public interface DataSetExecutor{
 
     IDataSet loadDataSets(String[] datasets) throws DataSetException, IOException;
 
-    void initConnectionFromConfig(ConnectionConfig connectionConfig) throws SQLException;
+    void initConnectionFromConfig(ConnectionConfig connectionConfig);
 
     void clearDatabase(DataSetConfig dataset) throws SQLException;
 
@@ -49,7 +49,7 @@ public interface DataSetExecutor{
 
     DBUnitConfig getDBUnitConfig();
 
-    RiderDataSource getRiderDataSource() throws DatabaseUnitException, SQLException;
+    RiderDataSource getRiderDataSource() throws SQLException;
 
     void enableConstraints() throws SQLException ;
 

--- a/rider-core/src/main/java/com/github/database/rider/core/api/leak/LeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/leak/LeakHunter.java
@@ -1,5 +1,7 @@
 package com.github.database.rider.core.api.leak;
 
+import com.github.database.rider.core.leak.LeakHunterException;
+
 /**
  * Created by pestano on 07/09/16.
  *
@@ -13,4 +15,14 @@ public interface LeakHunter {
      */
     int openConnections();
 
+    /**
+     * @return number of opened jdbc connections/sessions
+     */
+    int measureConnectionsBeforeExecution();
+
+    /**
+     * Check number of opened jdbc connections/sessions
+     * @throws LeakHunterException if the number of connections is greater than before execution
+     */
+    void checkConnectionsAfterExecution() throws LeakHunterException;
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
@@ -76,7 +76,7 @@ public class RiderDataSource {
         }
     }
 
-    private void configDatabaseProperties() throws SQLException {
+    private void configDatabaseProperties() {
         DatabaseConfig config = dbUnitConnection.getConfig();
         for (Map.Entry<String, Object> p : dbUnitConfig.getProperties().entrySet()) {
             ConfigProperty byShortName = DatabaseConfig.findByShortName(p.getKey());
@@ -104,7 +104,7 @@ public class RiderDataSource {
         }
     }
 
-    private DBType resolveDBType(String driverName) throws SQLException {
+    private DBType resolveDBType(String driverName) {
         if (DriverUtils.isHsql(driverName)) {
             return DBType.HSQLDB;
         } else if (DriverUtils.isH2(driverName)) {

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/H2LeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/H2LeakHunter.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 
 /**
  * Created by pestano on 07/09/16.
- *
+ * <p>
  * Leak hunter for H2
  */
 class H2LeakHunter extends AbstractLeakHunter {
@@ -13,12 +13,13 @@ class H2LeakHunter extends AbstractLeakHunter {
 
     private Connection connection;
 
-    public H2LeakHunter(Connection connection) {
+    public H2LeakHunter(Connection connection, String methodName) {
+        super(methodName);
         this.connection = connection;
     }
 
 
-     @Override
+    @Override
     protected String leakCountSql() {
         return sql;
     }

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/HsqlDBLeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/HsqlDBLeakHunter.java
@@ -13,10 +13,10 @@ class HsqlDBLeakHunter extends AbstractLeakHunter {
 
     private Connection connection;
 
-    public HsqlDBLeakHunter(Connection connection) {
+    public HsqlDBLeakHunter(Connection connection, String methodName) {
+        super(methodName);
         this.connection = connection;
     }
-
 
     @Override
     protected String leakCountSql() {

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/LeakHunterException.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/LeakHunterException.java
@@ -5,8 +5,7 @@ package com.github.database.rider.core.leak;
  */
 public class LeakHunterException extends RuntimeException {
 
-
     public LeakHunterException(String methodName, int numberOfConnections) {
-        super(String.format("Execution of method %s left %d open connection(s).",methodName,numberOfConnections));
+        super(String.format("Execution of method %s left %d open connection(s).", methodName, numberOfConnections));
     }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/MySqlLeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/MySqlLeakHunter.java
@@ -1,7 +1,5 @@
 package com.github.database.rider.core.leak;
 
-import com.github.database.rider.core.api.leak.LeakHunter;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -10,17 +8,16 @@ import java.sql.Statement;
 /**
  * Created by pestano on 07/09/16.
  */
-class MySqlLeakHunter implements LeakHunter {
-
+class MySqlLeakHunter extends AbstractLeakHunter {
 
     private final String sql = "SELECT COUNT(*) FROM v$session WHERE status = 'INACTIVE'";
 
     Connection connection;
 
-    public MySqlLeakHunter(Connection connection) {
+    public MySqlLeakHunter(Connection connection, String methodName) {
+        super(methodName);
         this.connection = connection;
     }
-
 
     @Override
     public int openConnections() {
@@ -39,5 +36,15 @@ class MySqlLeakHunter implements LeakHunter {
         } catch (SQLException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    @Override
+    protected String leakCountSql() {
+        return sql;
+    }
+
+    @Override
+    protected Connection getConnection() {
+        return connection;
     }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/OracleLeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/OracleLeakHunter.java
@@ -12,7 +12,8 @@ class OracleLeakHunter extends AbstractLeakHunter {
 
     Connection connection;
 
-    public OracleLeakHunter(Connection connection){
+    public OracleLeakHunter(Connection connection, String methodName) {
+        super(methodName);
         this.connection = connection;
     }
 

--- a/rider-core/src/main/java/com/github/database/rider/core/leak/PostgreLeakHunter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/leak/PostgreLeakHunter.java
@@ -11,7 +11,8 @@ class PostgreLeakHunter extends AbstractLeakHunter {
 
     Connection connection;
 
-    public PostgreLeakHunter(Connection connection){
+    public PostgreLeakHunter(Connection connection, String methodName) {
+        super(methodName);
         this.connection = connection;
     }
 

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitTestContext.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitTestContext.java
@@ -2,19 +2,11 @@ package com.github.database.rider.junit5;
 
 import com.github.database.rider.core.api.dataset.DataSetExecutor;
 import com.github.database.rider.core.api.leak.LeakHunter;
-import com.github.database.rider.core.configuration.DataSetConfig;
 
 public class DBUnitTestContext {
-	
-	
-	private DataSetExecutor executor;
-	
-	private LeakHunter leakHunter;
-	
-	private DataSetConfig dataSetConfig;
-	
-	private int openConnections;
 
+	private DataSetExecutor executor;
+	private LeakHunter leakHunter;
 
 	public DataSetExecutor getExecutor() {
 		return executor;
@@ -33,29 +25,4 @@ public class DBUnitTestContext {
 		this.leakHunter = leakHunter;
 		return this;
 	}
-
-
-	public DataSetConfig getDataSetConfig() {
-		return dataSetConfig;
-	}
-	
-	public DBUnitTestContext setDataSetConfig(DataSetConfig dataSetConfig) {
-		this.dataSetConfig = dataSetConfig;
-		return this;
-	}
-
-	public int getOpenConnections() {
-		return openConnections;
-	}
-
-	public DBUnitTestContext setOpenConnections(int openConnections) {
-		this.openConnections = openConnections;
-		return this;
-	}
-
-	
-	
-
-	
-	
 }

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/JUnit5RiderTestContext.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/JUnit5RiderTestContext.java
@@ -1,0 +1,39 @@
+package com.github.database.rider.junit5;
+
+import com.github.database.rider.core.AbstractRiderTestContext;
+import com.github.database.rider.core.api.dataset.DataSetExecutor;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+public class JUnit5RiderTestContext extends AbstractRiderTestContext {
+
+    private final ExtensionContext extensionContext;
+
+    public JUnit5RiderTestContext(DataSetExecutor executor, ExtensionContext extensionContext) {
+        super(executor);
+        this.extensionContext = extensionContext;
+    }
+
+    @Override
+    public String getMethodName() {
+        return extensionContext.getTestMethod()
+                .map(Method::getName)
+                .orElse(null);
+    }
+
+    @Override
+    public <T extends Annotation> T getMethodAnnotation(Class<T> clazz) {
+        return extensionContext.getTestMethod()
+                .map(m -> m.getAnnotation(clazz))
+                .orElse(null);
+    }
+
+    @Override
+    public <T extends Annotation> T getClassAnnotation(Class<T> clazz) {
+        return extensionContext.getTestClass()
+                .map(cl -> cl.getAnnotation(clazz))
+                .orElse(null);
+    }
+}

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/WithoutDataSetIt.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/WithoutDataSetIt.java
@@ -1,5 +1,7 @@
 package com.github.database.rider.junit5;
 
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+import com.github.database.rider.core.util.EntityManagerProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.runner.JUnitPlatform;
@@ -11,6 +13,9 @@ import org.junit.runner.RunWith;
 @ExtendWith(DBUnitExtension.class)
 @RunWith(JUnitPlatform.class)
 public class WithoutDataSetIt {
+
+    private ConnectionHolder connectionHolder = () ->
+            EntityManagerProvider.instance("junit5-pu").connection();
 
     @Test
     public void shouldNotFall() {


### PR DESCRIPTION
Extracting test runner logic in junit agnostic class allows:
- delete repeated test runner logic from modules. 
I have combined the logic in core and juni5 module thereby fixing connection leaks in junit5
- simplify writing custom runners. For example spring extension, that allow automatic registering connection from application context. If you are interested I can send that extension in another PR.