### PR TITLE
Allow to specify custom DataTypeFactory (issue #30)

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
@@ -8,6 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
+import org.dbunit.dataset.datatype.IDataTypeFactory;
 
 /**
  * Created by rafael-pestano on 30/08/2016. This annotation configures DBUnit properties
@@ -54,6 +55,11 @@ public @interface DBUnit {
      * @return boolean value which configures case-sensitive table names (also columns)
      */
     boolean caseSensitiveTableNames() default false;
+
+    /**
+     * @return value which configures DatabaseConfig.PROPERTY_DATATYPE_FACTORY
+     */
+    Class<? extends IDataTypeFactory> dataTypeFactoryClass() default IDataTypeFactory.class;
 
     /**
      * Specifies the orthography/letter-case strategy if {@link #caseSensitiveTableNames()} is set to <code>false</code>

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
@@ -3,6 +3,7 @@ package com.github.database.rider.core.configuration;
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.configuration.Orthography;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
+import org.dbunit.dataset.datatype.IDataTypeFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
@@ -116,6 +117,16 @@ public class DBUnitConfig {
 
         if (!"".equals(dbUnit.escapePattern())) {
             dbUnitConfig.addDBUnitProperty("escapePattern", dbUnit.escapePattern());
+        }
+
+        if (!dbUnit.dataTypeFactoryClass().isInterface()) {
+            try {
+                IDataTypeFactory factory = dbUnit.dataTypeFactoryClass().newInstance();
+                dbUnitConfig.addDBUnitProperty("datatypeFactory", factory);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("failed to instantiate datatypeFactory", e);
+            }
         }
 
         // declarative connection config

--- a/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
@@ -8,6 +8,7 @@ import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConfig.ConfigProperty;
 import org.dbunit.database.DatabaseConnection;
+import org.dbunit.dataset.datatype.IDataTypeFactory;
 import org.dbunit.ext.h2.H2DataTypeFactory;
 import org.dbunit.ext.hsqldb.HsqldbDataTypeFactory;
 import org.dbunit.ext.mysql.MySqlDataTypeFactory;
@@ -85,22 +86,28 @@ public class RiderDataSource {
             }
         }
 
+        if (!dbUnitConfig.getProperties().containsKey("datatypeFactory")) {
+            IDataTypeFactory dataTypeFactory = getDataTypeFactory(dbType);
+            if (dataTypeFactory != null) {
+                config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, dataTypeFactory);
+            }
+        }
+    }
+
+    private IDataTypeFactory getDataTypeFactory(DBType dbType) {
         switch (dbType) {
-        case HSQLDB:
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new HsqldbDataTypeFactory());
-            break;
-        case H2:
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new H2DataTypeFactory());
-            break;
-        case MYSQL:
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MySqlDataTypeFactory());
-            break;
-        case POSTGRESQL:
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
-            break;
-        case ORACLE:
-            config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
-            break;
+            case HSQLDB:
+                return new HsqldbDataTypeFactory();
+            case H2:
+                return new H2DataTypeFactory();
+            case MYSQL:
+                return new MySqlDataTypeFactory();
+            case POSTGRESQL:
+                return new PostgresqlDataTypeFactory();
+            case ORACLE:
+                return new Oracle10DataTypeFactory();
+            default:
+                return null;
         }
     }
 

--- a/rider-core/src/test/resources/config/sample-dbunit.yml
+++ b/rider-core/src/test/resources/config/sample-dbunit.yml
@@ -8,3 +8,4 @@ properties:
   fetchSize: 200
   allowEmptyFields: true
   escapePattern: "[?]"
+  datatypeFactory: !!com.github.database.rider.core.configuration.DBUnitConfigTest$MockDataTypeFactory {}


### PR DESCRIPTION
Added availability to explicitly specify datatypeFactory property for dbUnit:
1) via @DBUnit with dataTypeFactoryClass property
2) via dbunit.yml with properties.datatypeFactory

If one of this property was specified, then default resolving method would be skipped.