### PR TITLE
Allow DB Rider annotations to be used as meta-annotations (rider-spring)

### DIFF
--- a/rider-spring/src/main/java/com/github/database/rider/spring/SpringRiderTestContext.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/SpringRiderTestContext.java
@@ -3,6 +3,7 @@ package com.github.database.rider.spring;
 import com.github.database.rider.core.AbstractRiderTestContext;
 import com.github.database.rider.core.api.dataset.DataSetExecutor;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 import org.springframework.test.context.TestContext;
 
@@ -45,11 +46,11 @@ class SpringRiderTestContext extends AbstractRiderTestContext {
 
     @Override
     public <T extends Annotation> T getMethodAnnotation(Class<T> clazz) {
-        return testContext.getTestMethod().getAnnotation(clazz);
+        return AnnotatedElementUtils.findMergedAnnotation(testContext.getTestMethod(), clazz);
     }
 
     @Override
     public <T extends Annotation> T getClassAnnotation(Class<T> clazz) {
-        return testContext.getTestClass().getAnnotation(clazz);
+        return AnnotatedElementUtils.findMergedAnnotation(testContext.getTestClass(), clazz);
     }
 }

--- a/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSet.java
+++ b/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSet.java
@@ -1,0 +1,24 @@
+package com.github.database.rider.spring.dataset;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@DBUnit(caseSensitiveTableNames = true)
+@DBRider
+@DataSet
+public @interface MetaDataSet {
+
+    @AliasFor(annotation = DataSet.class, attribute = "value")
+    String[] value() default "test.yml";
+
+}

--- a/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSetIT.java
+++ b/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSetIT.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestConfig.class)
 @MetaDataSet
-public class MetaDataSetTest {
+public class MetaDataSetIT {
 
     @Autowired
     private EntityUtils entityUtils;

--- a/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSetTest.java
+++ b/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MetaDataSetTest.java
@@ -1,0 +1,31 @@
+package com.github.database.rider.spring.dataset;
+
+
+import com.github.database.rider.spring.config.TestConfig;
+import com.github.database.rider.spring.model.EntityUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+@MetaDataSet
+public class MetaDataSetTest {
+
+    @Autowired
+    private EntityUtils entityUtils;
+
+    @Test
+    public void testMetaAnnotationOnClass() {
+        entityUtils.assertValues("value1", "value2");
+    }
+
+    @Test
+    @MetaDataSet("test2.yml")
+    public void testMetaAnnotationOnMethod() {
+        entityUtils.assertValues("value3", "value4");
+    }
+}
+


### PR DESCRIPTION
This PR allows database-rider annotations to be used as meta-annotations. Fixes #79 for `rider-spring` module