### PR TITLE
Allow DB Rider annotations to be used as meta-annotations (rider-junit5)

### DIFF
--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.platform.commons.util.AnnotationUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -36,9 +37,10 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
             EntityManagerProvider.em().clear();
         }
 
-        DataSet dataSet = extensionContext.getRequiredTestMethod().getAnnotation(DataSet.class);
+        DataSet dataSet = AnnotationUtils.findAnnotation(extensionContext.getRequiredTestMethod(), DataSet.class).orElse(null);
+
         if (dataSet == null) {
-            dataSet = extensionContext.getRequiredTestClass().getAnnotation(DataSet.class);
+            dataSet = AnnotationUtils.findAnnotation(extensionContext.getRequiredTestClass(), DataSet.class).orElse(null);
         }
 
         DataSetExecutor executor;
@@ -98,7 +100,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
                 if (!field.isAccessible()) {
                     field.setAccessible(true);
                 }
-                ConnectionHolder connectionHolder = ConnectionHolder.class.cast(field.get(extensionContext.getRequiredTestInstance()));
+                ConnectionHolder connectionHolder = (ConnectionHolder) field.get(extensionContext.getRequiredTestInstance());
                 if (connectionHolder == null) {
                     throw new RuntimeException("ConnectionHolder not initialized correctly");
                 }
@@ -116,7 +118,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
                 if (!method.isAccessible()) {
                     method.setAccessible(true);
                 }
-                ConnectionHolder connectionHolder = ConnectionHolder.class.cast(method.invoke(extensionContext.getRequiredTestInstance()));
+                ConnectionHolder connectionHolder = (ConnectionHolder) method.invoke(extensionContext.getRequiredTestInstance());
                 if (connectionHolder == null) {
                     throw new RuntimeException("ConnectionHolder not initialized correctly");
                 }

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/JUnit5RiderTestContext.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/JUnit5RiderTestContext.java
@@ -3,6 +3,7 @@ package com.github.database.rider.junit5;
 import com.github.database.rider.core.AbstractRiderTestContext;
 import com.github.database.rider.core.api.dataset.DataSetExecutor;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -25,15 +26,12 @@ public class JUnit5RiderTestContext extends AbstractRiderTestContext {
 
     @Override
     public <T extends Annotation> T getMethodAnnotation(Class<T> clazz) {
-        return extensionContext.getTestMethod()
-                .map(m -> m.getAnnotation(clazz))
-                .orElse(null);
+        return AnnotationUtils.findAnnotation(extensionContext.getTestMethod(), clazz).orElse(null);
     }
 
     @Override
     public <T extends Annotation> T getClassAnnotation(Class<T> clazz) {
-        return extensionContext.getTestClass()
-                .map(cl -> cl.getAnnotation(clazz))
-                .orElse(null);
+        return AnnotationUtils.findAnnotation(extensionContext.getTestClass(), clazz).orElse(null);
+
     }
 }

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/AnotherMetaDataSet.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/AnotherMetaDataSet.java
@@ -1,0 +1,16 @@
+package com.github.database.rider.junit5;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@DataSet(value = "expectedUser.yml", disableConstraints = true)
+public @interface AnotherMetaDataSet {
+
+}

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/MetaDataSet.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/MetaDataSet.java
@@ -1,0 +1,19 @@
+package com.github.database.rider.junit5;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(DBUnitExtension.class)
+@DataSet(value = "users.yml", disableConstraints = true)
+public @interface MetaDataSet {
+
+
+}

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/MetaDataSetIt.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/MetaDataSetIt.java
@@ -1,0 +1,35 @@
+package com.github.database.rider.junit5;
+
+
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import com.github.database.rider.junit5.model.User;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitPlatform.class)
+@MetaDataSet
+public class MetaDataSetIt {
+
+    private ConnectionHolder connectionHolder = () -> //<3>
+            EntityManagerProvider.instance("junit5-pu").connection();
+
+    @Test
+    public void testMetaAnnotationOnClass() {
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u").getResultList();
+        assertThat(users).isNotNull().isNotEmpty().hasSize(2);
+    }
+
+    @Test
+    @AnotherMetaDataSet
+    public void testMetaAnnotationOnMethod() {
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u").getResultList();
+        assertThat(users).isNotNull().isNotEmpty().hasSize(1);
+    }
+}
+


### PR DESCRIPTION
This PR allows database-rider annotations to be used as meta-annotations. Fixes #79 for `rider-junit5` module