### PR TITLE
Custom replacers + NullReplacer, UnixTimestampReplacer

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
@@ -1,14 +1,10 @@
 package com.github.database.rider.core.api.configuration;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
+import com.github.database.rider.core.replacers.Replacer;
 import org.dbunit.dataset.datatype.IDataTypeFactory;
+
+import java.lang.annotation.*;
 
 /**
  * Created by rafael-pestano on 30/08/2016. This annotation configures DBUnit properties
@@ -60,6 +56,11 @@ public @interface DBUnit {
      * @return value which configures DatabaseConfig.PROPERTY_DATATYPE_FACTORY
      */
     Class<? extends IDataTypeFactory> dataTypeFactoryClass() default IDataTypeFactory.class;
+
+    /**
+     * @return implementations of {@link Replacer}, which are merged with default replacers
+     */
+    Class<? extends Replacer>[] replacers() default {};
 
     /**
      * Specifies the orthography/letter-case strategy if {@link #caseSensitiveTableNames()} is set to <code>false</code>

--- a/rider-core/src/main/java/com/github/database/rider/core/replacers/DateTimeReplacer.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/replacers/DateTimeReplacer.java
@@ -1,7 +1,6 @@
-package com.github.database.rider.core.replacer;
+package com.github.database.rider.core.replacers;
 
 import com.github.database.rider.core.api.replacer.*;
-import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ReplacementDataSet;
 
 import java.text.SimpleDateFormat;
@@ -11,55 +10,46 @@ import java.util.Date;
 /**
  * based on: http://marcin-michalski.pl/2012/10/22/decorating-dbunit-datasets-power-of-replacementdataset/
  */
-public class DateTimeReplacer {
+public class DateTimeReplacer implements Replacer {
 
     public static final SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     public static final String PLACEHOLDER_FORMAT = "[%s,%s]"; // [prefix:placeholderName]
 
-    private static DateTimeReplacer instance;
 
-    private DateTimeReplacer(){
-
-    }
-
-    public static IDataSet replace(IDataSet dataset) {
-        if (instance == null){
-            instance = new DateTimeReplacer();
-        }
+    @Override
+    public void addReplacements(ReplacementDataSet dataSet) {
         Date currentDate = new Date();
-        ReplacementDataSet replacementDataSet = new ReplacementDataSet(dataset);
-        instance.replaceDays(currentDate, replacementDataSet);
-        instance.replaceHours(currentDate, replacementDataSet);
-        instance.replaceMinutes(currentDate, replacementDataSet);
-        instance.replaceSeconds(currentDate, replacementDataSet);
-        return replacementDataSet;
+        replaceDays(currentDate, dataSet);
+        replaceHours(currentDate, dataSet);
+        replaceMinutes(currentDate, dataSet);
+        replaceSeconds(currentDate, dataSet);
     }
 
     private void replaceDays(Date currentDate, ReplacementDataSet replacementDataSet) {
         for (DayReplacerType type : DayReplacerType.values()) {
             Date calculatedDate = addDays(currentDate, type.getDays());
-            replacementDataSet.addReplacementSubstring(instance.getPlaceholderPattern(type), FORMAT.format(calculatedDate));
+            replacementDataSet.addReplacementSubstring(getPlaceholderPattern(type), FORMAT.format(calculatedDate));
         }
     }
 
     private void replaceHours(Date currentDate, ReplacementDataSet replacementDataSet) {
         for (HourReplacerType type : HourReplacerType.values()) {
             Date calculatedDate = addHours(currentDate, type.getHours());
-            replacementDataSet.addReplacementSubstring(instance.getPlaceholderPattern(type), FORMAT.format(calculatedDate));
+            replacementDataSet.addReplacementSubstring(getPlaceholderPattern(type), FORMAT.format(calculatedDate));
         }
     }
 
     private void replaceMinutes(Date currentDate, ReplacementDataSet replacementDataSet) {
         for (MinuteReplacerType type : MinuteReplacerType.values()) {
             Date calculatedDate = addMinutes(currentDate, type.getMinutes());
-            replacementDataSet.addReplacementSubstring(instance.getPlaceholderPattern(type), FORMAT.format(calculatedDate));
+            replacementDataSet.addReplacementSubstring(getPlaceholderPattern(type), FORMAT.format(calculatedDate));
         }
     }
 
     private void replaceSeconds(Date currentDate, ReplacementDataSet replacementDataSet) {
         for (SecondReplacerType type : SecondReplacerType.values()) {
             Date calculatedDate = addSeconds(currentDate, type.getSeconds());
-            replacementDataSet.addReplacementSubstring(instance.getPlaceholderPattern(type), FORMAT.format(calculatedDate));
+            replacementDataSet.addReplacementSubstring(getPlaceholderPattern(type), FORMAT.format(calculatedDate));
         }
     }
 

--- a/rider-core/src/main/java/com/github/database/rider/core/replacers/NullReplacer.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/replacers/NullReplacer.java
@@ -1,0 +1,16 @@
+package com.github.database.rider.core.replacers;
+
+import org.dbunit.dataset.ReplacementDataSet;
+
+/**
+ * Replacer which replaces [null] placehoder with actual {@code null} value.
+ *
+ * @author njuro
+ */
+public class NullReplacer implements Replacer {
+
+    @Override
+    public void addReplacements(ReplacementDataSet dataSet) {
+        dataSet.addReplacementObject("[null]", null);
+    }
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/replacers/Replacer.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/replacers/Replacer.java
@@ -1,0 +1,20 @@
+package com.github.database.rider.core.replacers;
+
+import org.dbunit.dataset.ReplacementDataSet;
+
+/**
+ * Common interface for all replacers.
+ *
+ * @author njuro
+ */
+public interface Replacer {
+
+
+    /**
+     * Registers new substitutions in data set through use of {@link ReplacementDataSet#addReplacementSubstring(String, String)}
+     * and {@link ReplacementDataSet#addReplacementObject(Object, Object)}.
+     *
+     * @param dataSet - replacement set
+     */
+    void addReplacements(ReplacementDataSet dataSet);
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/replacers/UnixTimestampReplacer.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/replacers/UnixTimestampReplacer.java
@@ -1,0 +1,17 @@
+package com.github.database.rider.core.replacers;
+
+import org.dbunit.dataset.ReplacementDataSet;
+
+/**
+ * Replacer which replaces [UNIX_TIMESTAMP] placeholder with Unix timestamp (obtained through {@link System#currentTimeMillis()}
+ *
+ * @author njuro
+ */
+public class UnixTimestampReplacer implements Replacer {
+
+    @Override
+    public void addReplacements(ReplacementDataSet dataSet) {
+        long timestamp = System.currentTimeMillis() / 1000L;
+        dataSet.addReplacementObject("[UNIX_TIMESTAMP]", timestamp);
+    }
+}

--- a/rider-core/src/test/java/com/github/database/rider/core/configuration/DBUnitConfigTest.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/configuration/DBUnitConfigTest.java
@@ -2,8 +2,8 @@ package com.github.database.rider.core.configuration;
 
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.configuration.Orthography;
+import com.github.database.rider.core.replacers.CustomReplacer;
 import org.dbunit.dataset.datatype.DataType;
-import org.dbunit.dataset.datatype.DataTypeException;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +50,7 @@ public class DBUnitConfigTest {
                 containsEntry("batchSize", 100).
                 containsEntry("fetchSize", 100).
                 containsEntry("allowEmptyFields", false).
+                containsKey("replacers").
                 doesNotContainKey("escapePattern").
                 doesNotContainKey("datatypeFactory");
 
@@ -83,7 +86,8 @@ public class DBUnitConfigTest {
                 containsEntry("batchSize", 200).
                 containsEntry("fetchSize", 200).
                 containsEntry("escapePattern", "[?]").
-                containsEntry("datatypeFactory", new MockDataTypeFactory());
+                containsEntry("datatypeFactory", new MockDataTypeFactory()).
+                containsEntry("replacers", new ArrayList<>(Arrays.asList(new CustomReplacer())));
     }
 
     @Test
@@ -142,12 +146,12 @@ public class DBUnitConfigTest {
 
     public static class MockDataTypeFactory implements org.dbunit.dataset.datatype.IDataTypeFactory {
         @Override
-        public DataType createDataType(int i, String s) throws DataTypeException {
+        public DataType createDataType(int i, String s) {
             throw new UnsupportedOperationException("only for configuration tests");
         }
 
         @Override
-        public DataType createDataType(int i, String s, String s1, String s2) throws DataTypeException {
+        public DataType createDataType(int i, String s, String s1, String s2) {
             throw new UnsupportedOperationException("only for configuration tests");
         }
 

--- a/rider-core/src/test/java/com/github/database/rider/core/model/Tweet.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/model/Tweet.java
@@ -22,6 +22,8 @@ public class Tweet {
     @Temporal(TemporalType.TIMESTAMP)
     private Calendar date;
 
+    private Long timestamp;
+
     @ManyToOne
     User user;
 
@@ -64,6 +66,14 @@ public class Tweet {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
     }
 
     @Override

--- a/rider-core/src/test/java/com/github/database/rider/core/model/lowercase/Tweet.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/model/lowercase/Tweet.java
@@ -22,6 +22,8 @@ public class Tweet {
     @Temporal(TemporalType.TIMESTAMP)
     private Calendar date;
 
+    private Long timestamp;
+
     @ManyToOne
     User user;
 
@@ -64,6 +66,14 @@ public class Tweet {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
     }
 
     @Override

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
@@ -1,0 +1,29 @@
+package com.github.database.rider.core.replacers;
+
+import com.github.database.rider.core.DBUnitRule;
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.model.Tweet;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBUnit(replacers = CustomReplacer.class)
+public class CustomReplacementIt {
+
+    @Rule
+    public EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
+
+    @Rule
+    public DBUnitRule dbUnitRule = DBUnitRule.instance("rules-it", emProvider.connection());
+
+    @Test
+    @DataSet(value = "datasets/yml/custom-replacements.yml", disableConstraints = true, executorId = "rules-it")
+    public void shouldReplaceFoo() {
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '1'").getSingleResult();
+        assertThat(tweet).isNotNull();
+        assertThat(tweet.getContent()).isNotNull().isEqualTo("BAR");
+    }
+}

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacer.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacer.java
@@ -1,0 +1,29 @@
+package com.github.database.rider.core.replacers;
+
+import org.dbunit.dataset.ReplacementDataSet;
+
+import java.util.Objects;
+
+/**
+ * Example implementation of {@link Replacer} which replaces string 'FOO' for 'BAR'
+ *
+ * @author njuro
+ */
+public class CustomReplacer implements Replacer {
+
+    @Override
+    public void addReplacements(ReplacementDataSet dataSet) {
+        dataSet.addReplacementSubstring("FOO", "BAR");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass());
+    }
+}

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/DateReplacementsIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/DateReplacementsIt.java
@@ -1,9 +1,10 @@
-package com.github.database.rider.core;
+package com.github.database.rider.core.replacers;
 
-import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.DBUnitRule;
 import com.github.database.rider.core.api.configuration.DBUnit;
-import com.github.database.rider.core.util.EntityManagerProvider;
+import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.model.Tweet;
+import com.github.database.rider.core.util.EntityManagerProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +35,7 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithNowPlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '1'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '1'").getSingleResult();
         assertThat(tweet).isNotNull();
         assertThat(tweet.getDate().get(Calendar.DAY_OF_MONTH)).isEqualTo(now.get(Calendar.DAY_OF_MONTH));
         assertThat(tweet.getDate().get(Calendar.HOUR_OF_DAY)).isEqualTo(now.get(Calendar.HOUR_OF_DAY));
@@ -43,7 +44,7 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithYesterdayPlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '2'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '2'").getSingleResult();
         assertThat(tweet).isNotNull();
         Calendar date = (Calendar)tweet.getDate().clone();
         date.add(Calendar.DAY_OF_MONTH, 1);
@@ -53,7 +54,7 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithTomorrowPlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '3'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '3'").getSingleResult();
         assertThat(tweet).isNotNull();
         Calendar date = (Calendar)tweet.getDate().clone();
         date.add(Calendar.DAY_OF_MONTH, -1);
@@ -63,7 +64,7 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithYearAfterPlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '4'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '4'").getSingleResult();
         assertThat(tweet).isNotNull();
         Calendar date = (Calendar)tweet.getDate().clone();
         date.add(Calendar.YEAR, -1);
@@ -73,7 +74,7 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithYearBeforePlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '5'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '5'").getSingleResult();
         assertThat(tweet).isNotNull();
         Calendar date = (Calendar)tweet.getDate().clone();
         date.add(Calendar.YEAR, 1);
@@ -83,10 +84,20 @@ public class DateReplacementsIt {
     @Test
     @DataSet(value = "datasets/yml/date-replacements.yml",disableConstraints = true, executorId = "rules-it")
     public void shouldReplaceDateWithHourPlaceHolder() {
-        Tweet tweet = (Tweet) emProvider.em().createQuery("select t from Tweet t where t.id = '6'").getSingleResult();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '6'").getSingleResult();
         assertThat(tweet).isNotNull();
         Calendar date = (Calendar)tweet.getDate().clone();
         date.add(Calendar.HOUR_OF_DAY, -1);
         assertThat(date.get(Calendar.HOUR_OF_DAY)).isEqualTo(now.get(Calendar.HOUR_OF_DAY));
     }
+
+    @Test
+    @DataSet(value = "datasets/yml/date-replacements.yml", disableConstraints = true, executorId = "rules-it")
+    public void shouldReplaceUnixTimestamp() {
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '7'").getSingleResult();
+        assertThat(tweet).isNotNull();
+        assertThat(tweet.getTimestamp()).isNotNull();
+        assertThat(tweet.getTimestamp()).isGreaterThan(1000L);
+    }
+
 }

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/NullReplacementsIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/NullReplacementsIt.java
@@ -1,0 +1,36 @@
+package com.github.database.rider.core.replacers;
+
+
+import com.github.database.rider.core.DBUnitRule;
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.model.Tweet;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBUnit(cacheConnection = true)
+public class NullReplacementsIt {
+
+    @Rule
+    public EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
+
+    @Rule
+    public DBUnitRule dbUnitRule = DBUnitRule.instance("rules-it", emProvider.connection());
+
+    @Test
+    @DataSet(value = "datasets/yml/null-replacements.yml", disableConstraints = true, executorId = "rules-it")
+    public void shouldReplaceNullPlaceholder() {
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '1'").getSingleResult();
+        assertThat(tweet).isNotNull();
+        assertThat(tweet.getContent()).isNull();
+
+        Tweet tweet2 = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '2'").getSingleResult();
+        assertThat(tweet2).isNotNull();
+        assertThat(tweet2.getContent()).isNotNull().isEqualTo("null");
+    }
+
+
+}

--- a/rider-core/src/test/resources/config/sample-dbunit.yml
+++ b/rider-core/src/test/resources/config/sample-dbunit.yml
@@ -9,3 +9,4 @@ properties:
   allowEmptyFields: true
   escapePattern: "[?]"
   datatypeFactory: !!com.github.database.rider.core.configuration.DBUnitConfigTest$MockDataTypeFactory {}
+  replacers: [!!com.github.database.rider.core.replacers.CustomReplacer {}]

--- a/rider-core/src/test/resources/datasets/yml/custom-replacements.yml
+++ b/rider-core/src/test/resources/datasets/yml/custom-replacements.yml
@@ -1,0 +1,4 @@
+TWEET:
+- ID: "1"
+  CONTENT: "FOO"
+  USER_ID: 1

--- a/rider-core/src/test/resources/datasets/yml/date-replacements.yml
+++ b/rider-core/src/test/resources/datasets/yml/date-replacements.yml
@@ -23,5 +23,9 @@ TWEET:
     CONTENT: "dbunit rules!"
     DATE: "[HOUR,PLUS_ONE]"
     USER_ID: 1
+  - ID: "7"
+    CONTENT: "dbunit rules!"
+    USER_ID: 1
+    TIMESTAMP: "[UNIX_TIMESTAMP]"
 
 

--- a/rider-core/src/test/resources/datasets/yml/null-replacements.yml
+++ b/rider-core/src/test/resources/datasets/yml/null-replacements.yml
@@ -1,0 +1,7 @@
+TWEET:
+- ID: "1"
+  CONTENT: "[null]"
+  USER_ID: 1
+- ID: "2"
+  CONTENT: "null"
+  USER_ID: 1


### PR DESCRIPTION
- Added `UnixTimestampReplacer`, which replaces _[UNIX_TIMESTAMP]_ with actual unix timestamp, as requested in #61 
- Added `NullReplacer`, which replaces _[null]_ with actual `null` value, as requested in #52 
- Added ability for user to register custom replacers, by implementing `Replacer` interface and then registering all replacers in global config, or referencing them via `@DBunit#replacers`. The latter will merge specified replacers with defaults, which are at this moment the two mentioned above + `DateTimeReplacer`, (already part of Database Rider). Fixes #52 