### PR TITLE
add support for DB2

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
@@ -2,6 +2,9 @@ package com.github.database.rider.core.api.configuration;
 
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 import com.github.database.rider.core.replacers.Replacer;
+
+import org.dbunit.database.DefaultMetadataHandler;
+import org.dbunit.database.IMetadataHandler;
 import org.dbunit.dataset.datatype.IDataTypeFactory;
 
 import java.lang.annotation.*;
@@ -57,6 +60,12 @@ public @interface DBUnit {
      */
     Class<? extends IDataTypeFactory> dataTypeFactoryClass() default IDataTypeFactory.class;
 
+    /**
+     * @return value which configures DatabaseConfig.PROPERTY_METADATA_HANDLER
+     */
+    Class<? extends IMetadataHandler> metaDataHandler() default IMetadataHandler.class;
+    
+    
     /**
      * @return implementations of {@link Replacer}, which are merged with default replacers
      */

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
@@ -7,6 +7,8 @@ import com.github.database.rider.core.replacers.DateTimeReplacer;
 import com.github.database.rider.core.replacers.NullReplacer;
 import com.github.database.rider.core.replacers.Replacer;
 import com.github.database.rider.core.replacers.UnixTimestampReplacer;
+
+import org.dbunit.database.IMetadataHandler;
 import org.dbunit.dataset.datatype.IDataTypeFactory;
 import org.yaml.snakeyaml.Yaml;
 
@@ -137,6 +139,17 @@ public class DBUnitConfig {
             }
         }
 
+        if (!dbUnit.metaDataHandler().isInterface()) {
+            try {
+                IMetadataHandler factory = dbUnit.metaDataHandler().newInstance();
+                dbUnitConfig.addDBUnitProperty("metadataHandler", factory);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("failed to instantiate datatypeFactory", e);
+            }
+        }
+        
+        
         List<Replacer> dbUnitReplacers = new ArrayList<>();
         for (Class<? extends Replacer> replacerClass : dbUnit.replacers()) {
             try {

--- a/rider-core/src/main/java/com/github/database/rider/core/util/DriverUtils.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/util/DriverUtils.java
@@ -28,6 +28,10 @@ public class DriverUtils {
     public static boolean isOracle(String driverName) {
         return driverName != null && driverName.contains("oracle");
     }
+    
+    public static boolean isDB2(String driverName) {
+    	return driverName != null && driverName.contains("db2");
+    }
 
     public static String getDriverName(Connection connection) {
         try {


### PR DESCRIPTION
Currently the database rider does not support DB2 natively. 

When running database rider against a DB2 to export a dataset, you get exceptions, because the DatatypeFactory and the MetadataHandler for DB2 is not configured automatically.

The MetadataHandler can only be configured in dbunit.yml, but in not in the DBUnit Annotation.

This fix sets the DatatypeFactory and MetadataHandler automatically, if a db2 driver is used (similar to the existing functionality for other databases)