### PR TITLE
Add orderBy option to @ExpectedDataSet

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
@@ -162,7 +162,7 @@ public class RiderRunner {
         ExpectedDataSet expectedDataSet = riderTestContext.getAnnotation(ExpectedDataSet.class);
 
         if (expectedDataSet != null) {
-            riderTestContext.getDataSetExecutor().compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).disableConstraints(true), expectedDataSet.ignoreCols(),expectedDataSet.replacers());
+            riderTestContext.getDataSetExecutor().compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).disableConstraints(true), expectedDataSet.ignoreCols(),expectedDataSet.replacers(),expectedDataSet.orderBy());
         }
     }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSetExecutor.java
@@ -51,9 +51,10 @@ public interface DataSetExecutor{
      * @param expected configuration
      * @param ignoreCols name of column to ignore
      * @param replacers implementations of {@link Replacer}, called during reading expected dataset before comparison
+     * @param orderBy name of columns to sort the dataset with
      * @throws DatabaseUnitException if current dataset is not equal current dataset
      */
-    void compareCurrentDataSetWith(DataSetConfig expected, String[] ignoreCols, Class<? extends Replacer>[] replacers) throws DatabaseUnitException;
+    void compareCurrentDataSetWith(DataSetConfig expected, String[] ignoreCols, Class<? extends Replacer>[] replacers, String[] orderBy) throws DatabaseUnitException;
 
     void setDBUnitConfig(DBUnitConfig dbUnitConfig);
 

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ExpectedDataSet.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ExpectedDataSet.java
@@ -28,4 +28,9 @@ public @interface ExpectedDataSet {
    * @return implementations of {@link Replacer} called during reading expected dataset before comparison
    */
   Class<? extends Replacer>[] replacers() default {};
+
+  /**
+   * @return column names to sort the dataset with
+   */
+  String[] orderBy() default {};
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -739,7 +739,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
 
     @Override
 	public void compareCurrentDataSetWith(DataSetConfig expectedDataSetConfig, String[] excludeCols,
-			Class<? extends Replacer>[] replacers) throws DatabaseUnitException {
+			Class<? extends Replacer>[] replacers, String[] orderBy) throws DatabaseUnitException {
         IDataSet current = null;
         IDataSet expected = null;
         List<Replacer> expectedDataSetReplacers = new ArrayList<>();
@@ -777,6 +777,17 @@ public class DataSetExecutorImpl implements DataSetExecutor {
             } catch (DataSetException e) {
                 throw new RuntimeException("DataSet comparison failed due to following exception: ", e);
             }
+            if (orderBy != null && orderBy.length > 0) {
+                for (int i=0; i<expectedTable.getRowCount(); i++) {
+                    for (String orderColumn : orderBy) {
+                        if (expectedTable.getValue(i, orderColumn).toString().startsWith("regex:")) {
+                            throw new IllegalArgumentException("The orderBy columns cannot use regex matching");
+                        }
+                    }
+                }
+                expectedTable = new SortedTable(expectedTable, orderBy);
+                actualTable = new SortedTable(actualTable, orderBy);
+            }
             ITable filteredActualTable = DefaultColumnFilter.includedColumnsTable(actualTable,
                     expectedTable.getTableMetaData().getColumns());
             DataSetAssertion.assertEqualsIgnoreCols(expectedTable, filteredActualTable, excludeCols);
@@ -787,7 +798,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
     @Override
     public void compareCurrentDataSetWith(DataSetConfig expectedDataSetConfig, String[] excludeCols)
             throws DatabaseUnitException {
-    	compareCurrentDataSetWith(expectedDataSetConfig,excludeCols,null);
+    	compareCurrentDataSetWith(expectedDataSetConfig,excludeCols,null,null);
 	}
 
     @Override

--- a/rider-core/src/test/java/com/github/database/rider/core/DataSetExecutorIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/DataSetExecutorIt.java
@@ -14,6 +14,7 @@ import com.github.database.rider.core.model.Follower;
 import com.github.database.rider.core.util.EntityManagerProvider;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 import com.github.database.rider.core.exception.DataBaseSeedingException;
+import org.dbunit.DatabaseUnitException;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -173,5 +174,12 @@ public class DataSetExecutorIt {
 	    assertThat(users.get(1).getName()).isEqualTo("@dbunit");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowAnExceptionIfExpectedDataSetHasBothOrderByAndRegex() throws DatabaseUnitException {
+        DataSetConfig DataSetConfig = new DataSetConfig("datasets/yml/users.yml");
+        executor.createDataSet(DataSetConfig);
+        DataSetConfig ExpectedDataSetConfig = new DataSetConfig("datasets/yml/expectedUsersRegex.yml");
+        executor.compareCurrentDataSetWith(ExpectedDataSetConfig, null, null, new String[] {"name"});
+    }
 
 }

--- a/rider-core/src/test/java/com/github/database/rider/core/ExpectedDataSetIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/ExpectedDataSetIt.java
@@ -111,6 +111,23 @@ public class ExpectedDataSetIt {
     // end::expectedWithSeeding[]
 
     @Test
+    @DataSet(value = "yml/empty.yml", disableConstraints = true)
+    @ExpectedDataSet(value = "yml/expectedUsersIgnoreOrder.yml", orderBy = "name")
+    public void shouldMatchExpectedDataSetIgnoringRowOrder() {
+        User u1 = new User();
+        u1.setName("@arhohuttunen");
+        User u2 = new User();
+        u2.setName("@realpestano");
+        User u3 = new User();
+        u3.setName("@dbunit");
+        tx().begin();
+        em().persist(u1);
+        em().persist(u2);
+        em().persist(u3);
+        tx().commit();
+    }
+
+    @Test
     @DataSet(value = "yml/user.yml", disableConstraints = true, cleanBefore = true)
     @ExpectedDataSet(value = "yml/empty.yml")
     public void shouldMatchEmptyYmlDataSet() {

--- a/rider-core/src/test/resources/datasets/yml/expectedUsersIgnoreOrder.yml
+++ b/rider-core/src/test/resources/datasets/yml/expectedUsersIgnoreOrder.yml
@@ -1,0 +1,4 @@
+USER:
+  - NAME: "@realpestano"
+  - NAME: "@arhohuttunen"
+  - NAME: "@dbunit"


### PR DESCRIPTION
When using ignoreOrder=true with @ExpectedDataSet Database Rider will take the columns from the expected dataset and use those to sort the actual and expected dataset rows before comparison.