### PR TITLE
SonarQube - String Literals on the left on comparisons

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/GlobalConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/GlobalConfig.java
@@ -30,7 +30,7 @@ public class GlobalConfig {
         DBUnitConfig dbUnitConfig = DBUnitConfig.fromCustomGlobalFile();
 
         if (dbUnitConfig.getProperties().containsKey("escapePattern")
-                && dbUnitConfig.getProperties().get("escapePattern").equals("")) {
+                && "".equals(dbUnitConfig.getProperties().get("escapePattern"))) {
             // avoid Caused by: org.dbunit.DatabaseUnitRuntimeException: Empty string is an invalid escape pattern!
             // because @DBUnit annotation and dbunit.yml global config have escapePattern defaults to ""
             dbUnitConfig.getProperties().remove("escapePattern");

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -726,7 +726,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
 
     String[] readScriptStatements(URL resource) {
         String absolutePath = resource.getFile();
-        if (resource.getProtocol().equals("jar")) {
+        if ("jar".equals(resource.getProtocol())) {
             return readScriptStatementsFromJar(absolutePath);
         }
         return readScriptStatementsFromFile(new File(absolutePath));


### PR DESCRIPTION
Transforming from `someString.equals("string")`  to `"string".equals(someString)`. This avoids checking for `null` and also prevents `NullPointerException` being thrown.

These fixes SonarQube violations of the rule: [Strings literals should be placed on the left side when checking for equality](https://rules.sonarsource.com/java/RSPEC-1132)