### PR TITLE
SonarQube - Optimizing String.lastIndexOf() for single char

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ScriptableTable.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ScriptableTable.java
@@ -72,7 +72,7 @@ public class ScriptableTable implements ITable {
      * @return scriptEngine
      */
     private ScriptEngine getScriptEngine(String value) {
-        String engineName = value.substring(0, value.indexOf(":"));
+        String engineName = value.substring(0, value.indexOf(':'));
         if (engines.containsKey(engineName)) {
             return engines.get(engineName);
         } else {
@@ -92,7 +92,7 @@ public class ScriptableTable implements ITable {
      * @return script expression result
      */
     private Object getScriptResult(String script, ScriptEngine engine) throws ScriptException {
-        String scriptToExecute = script.substring(script.indexOf(":") + 1);
+        String scriptToExecute = script.substring(script.indexOf(':') + 1);
         return engine.eval(scriptToExecute);
     }
 

--- a/rider-core/src/main/java/com/github/database/rider/core/assertion/DataSetAssert.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/assertion/DataSetAssert.java
@@ -98,7 +98,7 @@ public class DataSetAssert extends DbUnitAssert {
     }
 
     private boolean regexMatches(String expectedValue, String actualValue) {
-        Pattern pattern = Pattern.compile(expectedValue.substring(expectedValue.indexOf(":")+1).trim());
+        Pattern pattern = Pattern.compile(expectedValue.substring(expectedValue.indexOf(':')+1).trim());
         return pattern.matcher(actualValue).matches();
     }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/exporter/DataSetExporter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/exporter/DataSetExporter.java
@@ -147,7 +147,7 @@ public class DataSetExporter {
                 }
                 case CSV: {
                     //csv needs a directory instead of file
-                    outputFile = outputFile.substring(0, outputFile.lastIndexOf("."));
+                    outputFile = outputFile.substring(0, outputFile.lastIndexOf('.'));
                     CsvDataSetWriter.write(dataSet, new File(outputFile));
                     break;
                 }
@@ -164,7 +164,7 @@ public class DataSetExporter {
 
             boolean generateBuilder = BuilderType.NONE != dataSetExportConfig.getBuilderType();
             if(generateBuilder) {
-                String builderName = outputFile.substring(0, outputFile.lastIndexOf("."))+".java";
+                String builderName = outputFile.substring(0, outputFile.lastIndexOf('.'))+".java";
                 new DataSetBuilderExporter().export(dataSet, new BuilderExportConfig(dataSetExportConfig.getBuilderType(), new File(builderName)));
             }
         } catch (Exception e) {


### PR DESCRIPTION
Replacing `String.lastIndexOf("/")` with `String.lastIndexOf('/')` which can be more performant.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)