### PR TITLE
SonarQube - Extracting constants from duplicated Strings

### DIFF
--- a/rider-core/src/perf/java/com/github/database/rider/RiderDataSetBenchmark.java
+++ b/rider-core/src/perf/java/com/github/database/rider/RiderDataSetBenchmark.java
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class RiderDataSetBenchmark {
 
+    private static final String PROBLEM_IN_BENCHMARK = "Problem in benchmark ";
+
     private static AtomicInteger yamlDatasetsCreated;
     private static AtomicInteger xmlDatasetsCreated;
     private static AtomicInteger jsonDatasetsCreated;
@@ -72,7 +74,7 @@ public class RiderDataSetBenchmark {
             assertCreatedDataSet(iDataSet);
             yamlDatasetsCreated.incrementAndGet();
         } catch (Exception e) {
-            LOG.error("Problem in benchmark " + ctx.toString(), e);
+            LOG.error(PROBLEM_IN_BENCHMARK + ctx.toString(), e);
         }
     }
 
@@ -83,7 +85,7 @@ public class RiderDataSetBenchmark {
             assertCreatedDataSet(iDataSet);
             xmlDatasetsCreated.incrementAndGet();
         } catch (Exception e) {
-            LOG.error("Problem in benchmark " + ctx.toString(), e);
+            LOG.error(PROBLEM_IN_BENCHMARK + ctx.toString(), e);
         }
     }
 
@@ -94,7 +96,7 @@ public class RiderDataSetBenchmark {
             assertCreatedDataSet(iDataSet);
             jsonDatasetsCreated.incrementAndGet();
         } catch (Exception e) {
-            LOG.error("Problem in benchmark " + ctx.toString(), e);
+            LOG.error(PROBLEM_IN_BENCHMARK + ctx.toString(), e);
         }
     }
 
@@ -129,7 +131,7 @@ public class RiderDataSetBenchmark {
             assertCreatedDataSet(iDataSet);
             programmaticDatasetsCreated.incrementAndGet();
         } catch (Exception e) {
-            LOG.error("Problem in benchmark " + ctx.toString(), e);
+            LOG.error(PROBLEM_IN_BENCHMARK + ctx.toString(), e);
         }
     }
 


### PR DESCRIPTION
Extracting constants from Strings that were duplicated at least 3 times. Considering only Strings with length >= 5.

This fixes SonarQube issues for the rule: [String literals should not be duplicated](https://rules.sonarsource.com/java/RSPEC-1192) 