### PR TITLE
fix bug with extra comma in json object

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by pestano on 11/09/16.
@@ -21,10 +23,10 @@ public class JSONWriter implements IDataSetConsumer {
 	private static final String NEW_LINE = System.getProperty("line.separator");
 	private static final String DOUBLE_SPACES = "  ";
 	private static final String FOUR_SPACES = DOUBLE_SPACES+DOUBLE_SPACES;
-	
+
     private static final Logger logger = LoggerFactory.getLogger(JSONWriter.class);
 
-	
+
 	private IDataSet dataSet;
 
 	private OutputStreamWriter out;
@@ -87,10 +89,8 @@ public class JSONWriter implements IDataSetConsumer {
 		rowCount++;
 		try {
 			out.write(FOUR_SPACES+"{"+NEW_LINE);
+			values = filterNullValues(values);
 			for (int i = 0; i < values.length; i++) {
-				if(values[i] == null){
-					continue;
-				}
 
 				Column currentColumn = metaData.getColumns()[i];
 				out.write(FOUR_SPACES+DOUBLE_SPACES+"\""+metaData.getColumns()[i].getColumnName() + "\": ");
@@ -99,8 +99,8 @@ public class JSONWriter implements IDataSetConsumer {
 					out.write("\"");
 				}
 				
-			    out.write(values[i].toString());
-			    
+				out.write(values[i].toString());
+
 				if (!isNumber) {
 					out.write("\"");
 				}
@@ -108,7 +108,7 @@ public class JSONWriter implements IDataSetConsumer {
 					out.write(",");
 				}
 				out.write(NEW_LINE);
-				
+
 			}
 			if(dataSet.getTable(metaData.getTableName()).getRowCount() != rowCount ){
 				out.write(FOUR_SPACES+"},"+NEW_LINE);
@@ -117,10 +117,19 @@ public class JSONWriter implements IDataSetConsumer {
 
 			}
 
-			
 		} catch (Exception e) {
 			logger.warn("Could not write row.", e);
 		}
+	}
+
+	private Object[] filterNullValues(Object[] values) {
+		List<Object> list = new ArrayList<>(values.length);
+		for (Object value : values) {
+			if(value != null){
+				list.add(value);
+			}
+		}
+		return list.toArray();
 	}
 
 	public synchronized void write() throws DataSetException {

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportNullPropertiesIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportNullPropertiesIt.java
@@ -96,9 +96,9 @@ public class ExportNullPropertiesIt {
     public void shouldNotExportNullColumnsInJSONDataSet() throws SQLException, DatabaseUnitException{
         DataSetExporter.getInstance().export(new DatabaseConnection(emProvider.connection()), new DataSetExportConfig().
                 dataSetFormat(DataSetFormat.JSON).outputFileName("target/userWithNullProperty.json"));
-        File xmlDataSet = new File("target/userWithNullProperty.json");
-        assertThat(xmlDataSet).exists();
-        assertThat(contentOf(xmlDataSet).replaceAll("\r","")).isEqualTo(("{"+NEW_LINE +
+        File jsonDataSet = new File("target/userWithNullProperty.json");
+        assertThat(jsonDataSet).exists();
+        assertThat(contentOf(jsonDataSet).replaceAll("\r","")).isEqualTo(("{"+NEW_LINE +
                 "  \"FOLLOWER\": ["+NEW_LINE +
                 "  ],"+NEW_LINE +
                 "  \"SEQUENCE\": ["+NEW_LINE +
@@ -111,7 +111,7 @@ public class ExportNullPropertiesIt {
                 "  ],"+NEW_LINE +
                 "  \"USER\": ["+NEW_LINE +
                 "    {"+NEW_LINE +
-                "      \"ID\": 1,"+NEW_LINE +
+                "      \"ID\": 1"+NEW_LINE +
                 "    }"+NEW_LINE +
                 "  ]"+NEW_LINE +
                 "}").replaceAll("\r",""));


### PR DESCRIPTION
During exporting database data to json file in the case when last values are null then there is added extra comma that is not valid json format
I mean, when we have a row with the next values:
```
|   column_1   | column_2 | column_3 | column_4 |
| -------------| -------- | -------- | -------- |
|  some value  |   null   |    42    |   null   |
```
then will be generated next json with the extra comma in the last object parameter
```(javascript)
{
    "tableName":[
         {
            "column_1": "some value",
            "column_3": 42,
        }
    ]
}

```