### PR TITLE
Add support for multiline strings in json export

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
@@ -12,8 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by pestano on 11/09/16.
@@ -34,8 +33,8 @@ public class JSONWriter implements IDataSetConsumer {
 	private int tableCount;
 	private int rowCount;
 
-	public JSONWriter(OutputStream outputStream, IDataSet dataSet) throws IOException {
-		out = new OutputStreamWriter(outputStream, "UTF-8");
+	public JSONWriter(OutputStream outputStream, IDataSet dataSet) {
+		out = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
 		this.dataSet = dataSet;
 	}
 
@@ -89,47 +88,54 @@ public class JSONWriter implements IDataSetConsumer {
 		rowCount++;
 		try {
 			out.write(FOUR_SPACES+"{"+NEW_LINE);
-			values = filterNullValues(values);
-			for (int i = 0; i < values.length; i++) {
-
-				Column currentColumn = metaData.getColumns()[i];
-				out.write(FOUR_SPACES+DOUBLE_SPACES+"\""+metaData.getColumns()[i].getColumnName() + "\": ");
-				boolean isNumber = currentColumn.getDataType().isNumber();
-				if (!isNumber) {
-					out.write("\"");
-				}
-				
-				out.write(values[i].toString());
-
-				if (!isNumber) {
-					out.write("\"");
-				}
-				if(i != values.length-1){
-					out.write(",");
-				}
-				out.write(NEW_LINE);
-
-			}
+			String sb = createSetFromColumnValues(values);
+			out.write(sb);
 			if(dataSet.getTable(metaData.getTableName()).getRowCount() != rowCount ){
 				out.write(FOUR_SPACES+"},"+NEW_LINE);
 			}else {
 				out.write(FOUR_SPACES+"}"+NEW_LINE);
-
 			}
+
 
 		} catch (Exception e) {
 			logger.warn("Could not write row.", e);
 		}
 	}
 
-	private Object[] filterNullValues(Object[] values) {
-		List<Object> list = new ArrayList<>(values.length);
-		for (Object value : values) {
-			if(value != null){
-				list.add(value);
+	private String createSetFromColumnValues(Object[] values) throws DataSetException {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < values.length; i++) {
+				if(values[i] == null){
+					continue;
+				}
+
+			Column currentColumn = metaData.getColumns()[i];
+			sb.append(FOUR_SPACES + DOUBLE_SPACES + "\"").append(metaData.getColumns()[i].getColumnName()).append("\": ");
+			boolean isNumber = currentColumn.getDataType().isNumber();
+			if (!isNumber) {
+				sb.append('"');
 			}
+
+			sb.append(values[i].toString());
+
+			if (!isNumber) {
+				sb.append('"');
+			}
+			if(i != values.length-1){
+				sb.append(',');
+			}
+			sb.append(NEW_LINE);
+
 		}
-		return list.toArray();
+		return replaceExtraCommaInTheEnd(sb);
+	}
+
+	private String replaceExtraCommaInTheEnd(StringBuilder sb) {
+		int indexOfPenultimateSymbol = sb.length() - 2;
+		if(sb.length() > 1 && sb.charAt(indexOfPenultimateSymbol) == ','){
+			sb.deleteCharAt(indexOfPenultimateSymbol);
+		}
+		return sb.toString();
 	}
 
 	public synchronized void write() throws DataSetException {

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/writer/JSONWriter.java
@@ -88,7 +88,7 @@ public class JSONWriter implements IDataSetConsumer {
 		rowCount++;
 		try {
 			out.write(FOUR_SPACES+"{"+NEW_LINE);
-			String sb = createSetFromColumnValues(values);
+			String sb = createSetFromValues(values);
 			out.write(sb);
 			if(dataSet.getTable(metaData.getTableName()).getRowCount() != rowCount ){
 				out.write(FOUR_SPACES+"},"+NEW_LINE);
@@ -102,21 +102,22 @@ public class JSONWriter implements IDataSetConsumer {
 		}
 	}
 
-	private String createSetFromColumnValues(Object[] values) throws DataSetException {
+	private String createSetFromValues(Object[] values) throws DataSetException {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < values.length; i++) {
-				if(values[i] == null){
+			Object currentValue = values[i];
+			if(currentValue == null){
 					continue;
-				}
+			}
 
 			Column currentColumn = metaData.getColumns()[i];
-			sb.append(FOUR_SPACES + DOUBLE_SPACES + "\"").append(metaData.getColumns()[i].getColumnName()).append("\": ");
+			sb.append(FOUR_SPACES + DOUBLE_SPACES + '"').append(metaData.getColumns()[i].getColumnName()).append("\": ");
 			boolean isNumber = currentColumn.getDataType().isNumber();
 			if (!isNumber) {
 				sb.append('"');
 			}
 
-			sb.append(values[i].toString());
+			sb.append(currentValue.toString().replaceAll(NEW_LINE, "\\\\n"));
 
 			if (!isNumber) {
 				sb.append('"');

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportSomeNullPropertiesIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportSomeNullPropertiesIt.java
@@ -1,0 +1,84 @@
+package com.github.database.rider.core.exporter;
+
+import com.github.database.rider.core.api.dataset.DataSetFormat;
+import com.github.database.rider.core.api.exporter.DataSetExportConfig;
+import com.github.database.rider.core.model.Tweet;
+import com.github.database.rider.core.model.User;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.DatabaseConnection;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.database.rider.core.util.EntityManagerProvider.newInstance;
+import static com.github.database.rider.core.util.EntityManagerProvider.tx;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+/**
+ * Created by rafael-pestano on 28/09/2016.
+ */
+
+@RunWith(JUnit4.class)
+public class ExportSomeNullPropertiesIt {
+
+  private static final String NEW_LINE = System.getProperty("line.separator");
+  private static EntityManagerProvider emProvider;
+
+
+  @BeforeClass
+  public static void setup() {
+    emProvider = newInstance("rules-it");
+    tx().begin();
+    User u2 = new User();
+    u2.setId(1);
+    u2.setName(null);
+    List<Tweet> tweets = new ArrayList<>();
+    Tweet tweet = new Tweet();
+    tweet.setContent("tweet_content");
+    tweet.setLikes(3);
+    EntityManagerProvider.em().persist(tweet);
+    tweets.add(tweet);
+    u2.setTweets(tweets);
+    EntityManagerProvider.em().persist(u2);
+    tx().commit();
+  }
+
+  @Test
+  public void shouldNotExportNullColumnsInJSONDataSet() throws SQLException, DatabaseUnitException {
+    DataSetExporter.getInstance().export(new DatabaseConnection(emProvider.connection()), new DataSetExportConfig().
+      dataSetFormat(DataSetFormat.JSON).outputFileName("target/userWithNullProperty.json"));
+    File jsonDataSet = new File("target/userWithNullProperty.json");
+    assertThat(jsonDataSet).exists();
+    assertThat(contentOf(jsonDataSet).replaceAll("\r", "")).isEqualTo(("{" + NEW_LINE +
+      "  \"FOLLOWER\": [" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"SEQUENCE\": [" + NEW_LINE +
+      "    {" + NEW_LINE +
+      "      \"SEQ_NAME\": \"SEQ_GEN\"," + NEW_LINE +
+      "      \"SEQ_COUNT\": 50" + NEW_LINE +
+      "    }" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"TWEET\": [" + NEW_LINE +
+      "    {" + NEW_LINE +
+      "      \"ID\": \"1\"," + NEW_LINE +
+      "      \"CONTENT\": \"tweet_content\"," + NEW_LINE +
+      "      \"LIKES\": 3" + NEW_LINE +
+      "    }" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"USER\": [" + NEW_LINE +
+      "    {" + NEW_LINE +
+      "      \"ID\": 1" + NEW_LINE +
+      "    }" + NEW_LINE +
+      "  ]" + NEW_LINE +
+      "}").replaceAll("\r", ""));
+
+  }
+}

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportSomeNullPropertiesIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportSomeNullPropertiesIt.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
 /**
- * Created by rafael-pestano on 28/09/2016.
+ *  Created by TonnTamerlan on 26/11/2019.
  */
 
 @RunWith(JUnit4.class)

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportStringPropertyWithNewLineSymbolIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportStringPropertyWithNewLineSymbolIt.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
 /**
- * Created by rafael-pestano on 28/09/2016.
+ * Created by TonnTamerlan on 26/11/2019.
  */
 
 @RunWith(JUnit4.class)

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportStringPropertyWithNewLineSymbolIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportStringPropertyWithNewLineSymbolIt.java
@@ -1,0 +1,71 @@
+package com.github.database.rider.core.exporter;
+
+import com.github.database.rider.core.api.dataset.DataSetFormat;
+import com.github.database.rider.core.api.exporter.DataSetExportConfig;
+import com.github.database.rider.core.model.Tweet;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.DatabaseConnection;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.sql.SQLException;
+
+import static com.github.database.rider.core.util.EntityManagerProvider.newInstance;
+import static com.github.database.rider.core.util.EntityManagerProvider.tx;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+/**
+ * Created by rafael-pestano on 28/09/2016.
+ */
+
+@RunWith(JUnit4.class)
+public class ExportStringPropertyWithNewLineSymbolIt {
+
+  private static final String NEW_LINE = System.getProperty("line.separator");
+  private static EntityManagerProvider emProvider;
+
+
+  @BeforeClass
+  public static void setup() {
+    emProvider = newInstance("rules-it");
+    tx().begin();
+    Tweet tweet = new Tweet();
+    tweet.setContent("first_line\nsecond_line\nthird_line");
+    tweet.setLikes(3);
+    EntityManagerProvider.em().persist(tweet);
+    tx().commit();
+  }
+
+  @Test
+  public void shouldNotExportNullColumnsInJSONDataSet() throws SQLException, DatabaseUnitException {
+    DataSetExporter.getInstance().export(new DatabaseConnection(emProvider.connection()), new DataSetExportConfig().
+      dataSetFormat(DataSetFormat.JSON).outputFileName("target/userWithNullProperty.json"));
+    File jsonDataSet = new File("target/userWithNullProperty.json");
+    assertThat(jsonDataSet).exists();
+    assertThat(contentOf(jsonDataSet).replaceAll("\r", "")).isEqualTo(("{" + NEW_LINE +
+      "  \"FOLLOWER\": [" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"SEQUENCE\": [" + NEW_LINE +
+      "    {" + NEW_LINE +
+      "      \"SEQ_NAME\": \"SEQ_GEN\"," + NEW_LINE +
+      "      \"SEQ_COUNT\": 50" + NEW_LINE +
+      "    }" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"TWEET\": [" + NEW_LINE +
+      "    {" + NEW_LINE +
+      "      \"ID\": \"1\"," + NEW_LINE +
+      "      \"CONTENT\": \"first_line\\nsecond_line\\nthird_line\"," + NEW_LINE +
+      "      \"LIKES\": 3" + NEW_LINE +
+      "    }" + NEW_LINE +
+      "  ]," + NEW_LINE +
+      "  \"USER\": [" + NEW_LINE +
+      "  ]" + NEW_LINE +
+      "}").replaceAll("\r", ""));
+
+  }
+}


### PR DESCRIPTION
1. After the last version json export was a little bit broken (sorry:-)). In some cases in fields were saved not relevant values.
2. Also, json export did not work correctly in the case when in the field was stored multiline text.