### PR TITLE
in rider-spring/pom.xml, the dependency slf4j-simple should be test scoped

### DIFF
--- a/rider-spring/pom.xml
+++ b/rider-spring/pom.xml
@@ -46,6 +46,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.12</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
without being test scoped (like it is in all of the other dbrider modules), `rider-spring` exports an unnecessary implementation of `slf4j-api`, causing conflicts in any projects that depend upon it, forcing them to add an `<exclusion/>` to the dependency that they otherwise would not need to do.