### PR TITLE
Apply DBUnit escape pattern when getting table names

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -623,12 +623,11 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                 // tables containing 'SEQ' will NOT be cleared see https://github.com/rmpestano/dbunit-rules/issues/26
                 continue;
             }
-            final String escapedTableName = getEscapedTableName(tableName);
             try (Statement statement = connection.createStatement()) {
-                statement.executeUpdate("DELETE FROM " + escapedTableName + " where 1=1");
+                statement.executeUpdate("DELETE FROM " + tableName + " where 1=1");
                 connection.commit();
             } catch (Exception e) {
-                log.warn("Could not clear table " + escapedTableName + ", message:" + e.getMessage() + ", cause: "
+                log.warn("Could not clear table " + tableName + ", message:" + e.getMessage() + ", cause: "
                         + e.getCause());
             }
         }
@@ -661,7 +660,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
         if (tableNames != null && dbUnitConfig.isCacheTableNames()) {
             return tableNames;
         }
-        List<String> tables = new ArrayList<String>();
+        List<String> tables = new ArrayList<>();
         try (ResultSet result = getTablesFromMetadata(con)) {
             while (result.next()) {
                 String schema = resolveSchema(result);
@@ -669,6 +668,9 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                     String name = result.getString("TABLE_NAME");
                     if (RESERVED_TABLE_NAMES.contains(name.toLowerCase())) {
                         name = escapeTableName(name);
+                    } else {
+                        // table name escaping may have been defined as well
+                        name = getEscapedTableName(name);
                     }
                     tables.add(schema != null && !"".equals(schema.trim()) ? schema + "." + name : name);
                 }
@@ -680,7 +682,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
 
             return tables;
         } catch (SQLException ex) {
-            log.warn("An exception occured while trying to analyse the database.", ex);
+            log.warn("An exception occurred while trying to analyse the database.", ex);
             return new ArrayList<>();
         }
     }

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -602,7 +602,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                     // https://github.com/rmpestano/dbunit-rules/issues/26
                     continue;
                 }
-                final String escapedTableName = getEscapedTableName(table);
+                final String escapedTableName = applyDBUnitEscapePattern(table);
                 try (Statement statement = connection.createStatement()) {
                     statement.executeUpdate("DELETE FROM " + escapedTableName + " where 1=1");
                     connection.commit();
@@ -642,7 +642,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
         return skip;
     }
 
-    private String getEscapedTableName(String table) {
+    private String applyDBUnitEscapePattern(String table) {
         boolean hasEscapePattern = dbUnitConfig.getProperties().containsKey("escapePattern") && !"".equals(dbUnitConfig.getProperties().get("escapePattern").toString());
         if (hasEscapePattern) {
             String escapePattern = dbUnitConfig.getProperties().get("escapePattern").toString();
@@ -670,7 +670,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                         name = escapeTableName(name);
                     } else {
                         // table name escaping may have been defined as well
-                        name = getEscapedTableName(name);
+                        name = applyDBUnitEscapePattern(name);
                     }
                     tables.add(schema != null && !"".equals(schema.trim()) ? schema + "." + name : name);
                 }


### PR DESCRIPTION
I have a system running with Postgres 9.6 where all database table names are lowercase, except for one table used by Flyway to track updates, which is in uppercase.

When running a test which disables constraints, the test fails because of an an error in the generated sql statement for this table:
postgres> ERROR:  relation "myschema.schema_updates" does not exist
postgres> STATEMENT:  ALTER TABLE myschema.SCHEMA_UPDATES DISABLE TRIGGER ALL

This is the annotation I'm using for the test:
```
@Test
@DataSet(
  value = {"mydataset.xml"},
  disableConstraints = true,
  cleanBefore = true,
  strategy = SeedStrategy.INSERT"
)
```

This SCHEMA_UPDATES table is only accessed correctly when the table name is escaped. Something like this:
```
ALTER TABLE myschema."SCHEMA_UPDATES" DISABLE TRIGGER ALL
Query returned successfully with no result in 12 msec.
```

So I'm also configuring DBUnit to include escaping like this:
```
@DBUnit(qualifiedTableNames = true, caseSensitiveTableNames = true, escapePattern = "\"?\"")
```

However it does not work. I've noticed that when building the list of table names, reserved table names are escaped with some defaults, but the rest of the table names are not, even if DBUnit is set to do so. There's a method to escape table names which uses this DBUnit configuration, `getEscapedTableName()`, but it's used only for clearing the database. It's not used, for example, when disabling/enabling constraints.


Maybe it's a better solution to apply the escaping, if set, when building the list of table names, and then other methods, when getting the list of tables from `getTableNames()` will already get the escaped names.

Am I missing something else? :) Please let me know. Thank you.