### PR TITLE
Add support for column sensing feature in FlatXML

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
@@ -89,6 +89,14 @@ public @interface DBUnit {
     boolean mergeDataSets() default false;
 
     /**
+     * If enabled, when loading datasets, reads in the whole XML into a buffer and dynamically adds new columns as they appear.
+     * This way, it's not necessary to define all possible columns on the first line.
+     *
+     * @return Enables or disables column sensing. Defaults to false.
+     */
+    boolean columnSensing() default false;
+
+    /**
      * Allow to call INSERT/UPDATE with empty strings ('').
      * 
      * @return value which configures DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS. Defaults to false.

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
@@ -27,6 +27,7 @@ public class DBUnitConfig {
     private Boolean cacheTableNames;
     private Boolean leakHunter;
     private Boolean mergeDataSets;
+    private Boolean columnSensing;
     private Orthography caseInsensitiveStrategy;
     private Map<String, Object> properties;
     private ConnectionConfig connectionConfig;
@@ -50,6 +51,7 @@ public class DBUnitConfig {
         leakHunter = false;
         caseInsensitiveStrategy = Orthography.UPPERCASE;
         mergeDataSets = Boolean.FALSE;
+        columnSensing = Boolean.FALSE;
 
         initDefaultProperties();
         initDefaultConnectionConfig();
@@ -122,6 +124,7 @@ public class DBUnitConfig {
                 .cacheTableNames(dbUnit.cacheTableNames())
                 .leakHunter(dbUnit.leakHunter())
                 .mergeDataSets(dbUnit.mergeDataSets())
+                .columnSensing(dbUnit.columnSensing())
                 .addDBUnitProperty("batchedStatements", dbUnit.batchedStatements())
                 .addDBUnitProperty("batchSize", dbUnit.batchSize())
                 .addDBUnitProperty("allowEmptyFields", dbUnit.allowEmptyFields())
@@ -225,6 +228,11 @@ public class DBUnitConfig {
         return this;
     }
 
+    public DBUnitConfig columnSensing(boolean columnSensing) {
+        this.columnSensing = columnSensing;
+        return this;
+    }
+
     public DBUnitConfig caseInsensitiveStrategy(Orthography orthography) {
         this.caseInsensitiveStrategy = orthography;
         return this;
@@ -284,7 +292,10 @@ public class DBUnitConfig {
     public Boolean isMergeDataSets() {
         return mergeDataSets;
     }
-    
+
+    public Boolean isColumnSensing() {
+        return columnSensing;
+    }
 
     public Boolean isLeakHunter() {
         return leakHunter;

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -170,7 +170,8 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                     .append("cacheTableNames: ").append(dbUnitConfig.isCacheTableNames()).append("\n")
                     .append("mergeDataSets: ").append(dbUnitConfig.isMergeDataSets()).append("\n")
                     .append("caseInsensitiveStrategy: ").append(dbUnitConfig.getCaseInsensitiveStrategy()).append("\n")
-                    .append("leakHunter: ").append("" + dbUnitConfig.isLeakHunter()).append("\n");
+                    .append("leakHunter: ").append("" + dbUnitConfig.isLeakHunter()).append("\n")
+                    .append("columnSensing: ").append("" + dbUnitConfig.isColumnSensing()).append("\n");
 
             for (Entry<String, Object> entry : dbUnitConfig.getProperties().entrySet()) {
                 sb.append(entry.getKey()).append(": ").append(entry.getValue() == null ? "" : entry.getValue()).append("\n");
@@ -240,9 +241,15 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                 }
                 case "xml": {
                     try {
-                        target = new ScriptableDataSet(sensitiveTableNames, new FlatXmlDataSetBuilder().setCaseSensitiveTableNames(sensitiveTableNames).build(getDataSetUrl(dataSetName)));
+                        target = new ScriptableDataSet(sensitiveTableNames, new FlatXmlDataSetBuilder()
+                            .setColumnSensing(dbUnitConfig.isColumnSensing())
+                            .setCaseSensitiveTableNames(sensitiveTableNames)
+                            .build(getDataSetUrl(dataSetName)));
                     } catch (Exception e) {
-                        target = new ScriptableDataSet(sensitiveTableNames, new FlatXmlDataSetBuilder().setCaseSensitiveTableNames(sensitiveTableNames).build(getDataSetStream(dataSetName)));
+                        target = new ScriptableDataSet(sensitiveTableNames, new FlatXmlDataSetBuilder()
+                            .setColumnSensing(dbUnitConfig.isColumnSensing())
+                            .setCaseSensitiveTableNames(sensitiveTableNames)
+                            .build(getDataSetStream(dataSetName)));
                     }
                     break;
                 }

--- a/rider-core/src/test/java/com/github/database/rider/core/DBUnitColumnSensingIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/DBUnitColumnSensingIt.java
@@ -1,0 +1,48 @@
+package com.github.database.rider.core;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.model.User;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+@DataSet(value = "xml/user-with-omitted-columns.xml", cleanBefore = true)
+public class DBUnitColumnSensingIt {
+	@Rule
+	public EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
+	@Rule
+	public DBUnitRule dbUnitRule = DBUnitRule.instance(emProvider.connection());
+
+	@Test
+	public void columnNotDefinedBeforeShouldBeNull() {
+		// GIVEN a dataset whose first row does not include all possible columns
+		// AND GIVEN that the DBUnit column sensing feature is disabled
+
+		// WHEN querying for a row that is known to have additional columns compared to the first row
+		User userWithNullName = (User) EntityManagerProvider.em().createQuery("from User u where u.id = '2'")
+				.getSingleResult();
+
+		// THEN the value of one of those columns is null
+		assertThat(userWithNullName.getName()).isNull();
+	}
+
+	@Test
+	@DBUnit(columnSensing = true)
+	public void columnNotDefinedBeforeShouldNotBeNull() {
+		// GIVEN a dataset whose first row does not include all possible columns
+		// AND GIVEN that the DBUnit column sensing feature is now enabled
+
+		// WHEN querying for a row that is known to have additional columns compared to the first row
+		User userWithName = (User) EntityManagerProvider.em().createQuery("from User u where u.id = '2'")
+				.getSingleResult();
+
+		// THEN the value of one of those columns is not null
+		assertThat(userWithName.getName()).isNotNull();
+	}
+}

--- a/rider-core/src/test/resources/datasets/xml/user-with-omitted-columns.xml
+++ b/rider-core/src/test/resources/datasets/xml/user-with-omitted-columns.xml
@@ -1,0 +1,4 @@
+<dataset>
+    <USER id="1" />
+    <USER id="2" name="@dbunit" />
+</dataset>


### PR DESCRIPTION
I've been trying to use a dataset with some rows where some columns are omitted (because of null values), but any column not specified on the first row gets ignored by DBUnit. There's a feature named ["column sensing"](http://dbunit.sourceforge.net/faq.html#differentcolumnnumber) that can be used in this situation, but I've been unable to enable it through Database Rider. I've searched in the issues list and the closed pull requests, but I haven't found anything.

This is a first attempt at passing that configuration to DBUnit. Although this works in the project where I'm using it, please consider it as a work in progress. Before trying to do some integration tests, please let me know if you have any ideas, concerns, etc. Thank you.