### PR TITLE
Adds RiderDSL to make it possible to populate database in a fluent way.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -235,31 +235,38 @@ public class DataSetExecutorIt {
 <1> As we are not using @Rule, which is responsible for reading @DataSet annotation, we have to provide *DataSetConfig* so executor can create the dataset.
 <2> this is done implicitly by *@Rule DBUnitRule*.
 
-DataSet executor setup and logic is `hidden` by DBUnit @Rule and @DataSet annotation:
+DataSet executor setup and logic is `hidden` by DBUnit @Rule and @DataSet annotation.
 
-[source, java]
+[IMPORTANT]
+====
+Since `v1.13.0` you can use <<RiderDSL>> which provides a fluent api as an alternative to DataSetExecutor (and `@DataSet`):
+
+[source,java]
 ----
 import static com.github.database.rider.util.EntityManagerProvider.em;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.database.rider.util.EntityManagerProvider.instance;
 
 @RunWith(JUnit4.class)
-public class ConnectionHolderIt {
+public class DataSetExecutorIt {
 
-    @Rule
-    public EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
-
-    @Rule
-    public DBUnitRule dbUnitRule = DBUnitRule.
-        instance(() -> emProvider.getConnection());
+    public EntityManagerProvider emProvider = instance("executor-it");
 
     @Test
-    @DataSet("yml/users.yml")
-    public void shouldListUsers() {
-        List<User> users = em().createQuery("select u from User u").getResultList();
-    	assertThat(users).isNotNull().isNotEmpty().hasSize(2);
-    }
+    public void shouldSeedUserDataSetUsingRiderDSL() {
+         RiderDSL.withConnection(emProvider.getConnection())
+                 .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml")
+                                   .cleanBefore(true))
+                 .withDBUnitConfig(new DBUnitConfig()
+                                   .addDBUnitProperty("caseSensitiveTableNames", false))
+                 .createDataSet();
+         User user = (User) em().createQuery("select u from User u where u.id = 1").getSingleResult();
+         assertThat(user).isNotNull();
+         assertThat(user.getId()).isEqualTo(1);
+      }
 }
 ----
+
+====
 
 === Configuration
 
@@ -1137,6 +1144,31 @@ However, you can pass a DBUnit configuration when creating your dataset provider
 
 NOTE: Configuration from `@DataSet` is used the same way as in file based datasets.
 
+=== RiderDSL
+
+If you cannot rely on `@DataSet` annotation because your test runner will not read it (e.g cucumber test runner, spock, kotlin test etc...) or because you don't like annotations, you can use *RiderDSL* to create datasets:
+
+[source, java]
+----
+    @Test
+     /*same as: @DataSet(value = "yml/user.yml", cleanBefore=true)
+                @DBUnit(caseSensitiveTableNames = false) */
+    public void shouldSeedDatabaseUsingRiderDSL() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSetConfig(new DataSetConfig("datasets/yml/user.yml")
+                        .cleanBefore(true))
+                .withDBUnitConfig(new DBUnitConfig().addDBUnitProperty("caseSensitiveTableNames", false))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
+        assertThat(users).
+                isNotNull().
+                isNotEmpty().
+                hasSize(2);
+    }
+----
+
+TIP: See more https://github.com/database-rider/database-rider/blob/master/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java#L24[examples here^].
+
 === Dynamic connection config
 
 In order to have dynamic JDBC connection on your tests one can use system properties, see example below:
@@ -1505,7 +1537,7 @@ public class ContactSteps {
 
 You can create datasets without JUnit Rule or CDI as we saw above, here is a pure cucumber example (for the same https://github.com/database-rider/database-rider#51-examples[feature above]):
 
-NOTE: If you are looking for a way to *define datasets programmatically* look into https://github.com/database-rider/database-rider#dataset-providers[DataSet providers^].
+NOTE: If you are looking for a way to *define datasets programmatically* look into <<DataSet providers>>.
 
 [source,java,linenums]
 ----
@@ -1576,6 +1608,8 @@ public class ContactStepsWithoutCDI {
     }
 }
 ----
+
+TIP: For a fluent API to create datasets, you can use <<RiderDSL>> instead of DataSetExecutor.
 
 == JUnit 5
 

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
@@ -31,15 +31,11 @@ public class DataSetConfig {
     public DataSetConfig() {
     }
 
-    public DataSetConfig(String dataset) {
-        this.datasets = new String[]{dataset};
-    }
-
-    public DataSetConfig(String[] datasets) {
+    public DataSetConfig(String... datasets) {
         this.datasets = datasets;
     }
 
-    public DataSetConfig name(String[] datasets) {
+    public DataSetConfig name(String... datasets) {
         this.datasets = datasets;
         return this;
     }
@@ -64,7 +60,7 @@ public class DataSetConfig {
         return this;
     }
 
-    public DataSetConfig tableOrdering(String[] tableOrdering) {
+    public DataSetConfig tableOrdering(String... tableOrdering) {
         this.tableOrdering = tableOrdering;
         return this;
     }
@@ -79,22 +75,22 @@ public class DataSetConfig {
         return this;
     }
 
-    public DataSetConfig executeStatementsBefore(String[] executeStatementsBefore) {
+    public DataSetConfig executeStatementsBefore(String... executeStatementsBefore) {
         this.executeStatementsBefore = executeStatementsBefore;
         return this;
     }
 
-    public DataSetConfig executeStatementsAfter(String[] executeStatementsAfter) {
+    public DataSetConfig executeStatementsAfter(String... executeStatementsAfter) {
         this.executeStatementsAfter = executeStatementsAfter;
         return this;
     }
 
-    public DataSetConfig executeScripsBefore(String[] executeScriptsBefore) {
+    public DataSetConfig executeScripsBefore(String... executeScriptsBefore) {
         this.executeScriptsBefore = executeScriptsBefore;
         return this;
     }
 
-    public DataSetConfig executeScriptsAfter(String[] executeScriptsAfter) {
+    public DataSetConfig executeScriptsAfter(String... executeScriptsAfter) {
         this.executeScriptsAfter = executeScriptsAfter;
         return this;
     }
@@ -116,7 +112,7 @@ public class DataSetConfig {
         return this;
     }
 
-    public DataSetConfig skipCleaningFor(String[] skipCleaningFor) {
+    public DataSetConfig skipCleaningFor(String... skipCleaningFor) {
         this.skipCleaningFor = skipCleaningFor;
         return this;
     }
@@ -209,7 +205,7 @@ public class DataSetConfig {
         return cleanAfter;
     }
 
-    public void setstrategy(SeedStrategy strategy) {
+    public void setStrategy(SeedStrategy strategy) {
         this.strategy = strategy;
     }
 
@@ -237,8 +233,8 @@ public class DataSetConfig {
         this.tableOrdering = tableOrdering;
     }
 
-    public void setTSkipCleaningFor(String[] tablesToClean) {
-        this.skipCleaningFor = tablesToClean;
+    public void setSkipCleaningFor(String[] skipCleaningFor) {
+        this.skipCleaningFor = skipCleaningFor;
     }
 
     public void setTransactional(boolean transactional) {
@@ -248,8 +244,10 @@ public class DataSetConfig {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (String dataset : datasets) {
-            sb.append(dataset).append(", ");
+        if(hasDataSets()) {
+            for (String dataset : datasets) {
+                sb.append(dataset).append(", ");
+            }
         }
         if(hasDataSetProvider()) {
             sb.append("dataset provider: "+provider.getName()).append(", ");

--- a/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
@@ -1,0 +1,87 @@
+package com.github.database.rider.core.dsl;
+
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.configuration.DataSetConfig;
+import com.github.database.rider.core.connection.ConnectionHolderImpl;
+import com.github.database.rider.core.dataset.DataSetExecutorImpl;
+
+import java.sql.Connection;
+
+public class RiderDSL {
+
+    private static RiderDSL INSTANCE;
+    private Connection connection;
+    private DataSetConfig dataSetConfig;
+    private DBUnitConfig dbUnitConfig;
+
+
+    public void createDataSet() {
+        validateConnection(connection);
+        validateDataSetConfig(dataSetConfig);
+        final DataSetExecutorImpl dataSetExecutor = DataSetExecutorImpl.instance(dataSetConfig.getExecutorId(), new ConnectionHolderImpl(connection));
+        if (dbUnitConfig != null) {
+            dataSetExecutor.setDBUnitConfig(dbUnitConfig);
+        }
+        dataSetExecutor.createDataSet(dataSetConfig);
+    }
+
+    private static void createInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new RiderDSL();
+        }
+    }
+
+    public static DataSetConfigDSL withConnection(Connection connection) {
+        createInstance();
+        validateConnection(connection);
+        INSTANCE.connection = connection;
+        return new DataSetConfigDSL();
+    }
+
+    /**
+     * Reuses current connection configured in the DSL
+     * @return DataSet config DSL
+     */
+    public static DataSetConfigDSL withConnection() {
+        return withConnection(INSTANCE.connection);
+    }
+
+    public static class DataSetConfigDSL {
+
+        public static DBUnitConfigDSL withDataSet(DataSetConfig dataSetConfig) {
+            validateDataSetConfig(dataSetConfig);
+            INSTANCE.dataSetConfig = dataSetConfig;
+            return new DBUnitConfigDSL();
+        }
+
+        public static DBUnitConfigDSL withDataSet() {
+            return withDataSet(INSTANCE.dataSetConfig);
+        }
+
+    }
+
+    public static class DBUnitConfigDSL {
+
+        public static RiderDSL withDBUnitConfig(DBUnitConfig dbUnitConfig) {
+            INSTANCE.dbUnitConfig = dbUnitConfig;
+            return INSTANCE;
+        }
+
+        public static void createDataSet() {
+            INSTANCE.createDataSet();
+        }
+    }
+
+    private static void validateConnection(Connection connection) {
+        if (connection == null) {
+            throw new RuntimeException("Invalid jdbc connection.");
+        }
+    }
+
+    private static void validateDataSetConfig(DataSetConfig dataSetConfig) {
+        if (dataSetConfig == null || (!dataSetConfig.hasDataSets() && !dataSetConfig.hasDataSetProvider())) {
+            throw new RuntimeException("Invalid dataset configuration. You must provide at least one dataset or dataset provider.");
+        }
+    }
+
+}

--- a/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
@@ -69,7 +69,7 @@ public class RiderDSL {
          * @param dataSetConfig {@link DataSetConfig}
          * @return A DBUnitConfigDSL to create DBUnit configuration ({@link DBUnitConfig}
          */
-        public static DBUnitConfigDSL withDataSet(DataSetConfig dataSetConfig) {
+        public static DBUnitConfigDSL withDataSetConfig(DataSetConfig dataSetConfig) {
             getInstance().dataSetConfig = dataSetConfig;
             return new DBUnitConfigDSL();
         }
@@ -79,8 +79,8 @@ public class RiderDSL {
          *
          * @return A DBUnitConfigDSL to create DBUnit configuration ({@link DBUnitConfig}
          */
-        public static DBUnitConfigDSL withDataSet() {
-            return withDataSet(getInstance().dataSetConfig);
+        public static DBUnitConfigDSL withDataSetConfig() {
+            return withDataSetConfig(getInstance().dataSetConfig);
         }
 
     }

--- a/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dsl/RiderDSL.java
@@ -7,6 +7,11 @@ import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 
 import java.sql.Connection;
 
+/**
+ * @author rmpestano
+ * @since 1.13.0
+ * DSL for populating database which is an alternative to `@DataSet` annotation
+ */
 public class RiderDSL {
 
     private static RiderDSL INSTANCE;
@@ -15,6 +20,10 @@ public class RiderDSL {
     private DBUnitConfig dbUnitConfig;
 
 
+    /**
+     * Creates a dataset in database using the provided connection ({@link Connection}), dataset configuration ({@link DataSetConfig}
+     * and dbunit configuration ({@link DBUnitConfig})
+     */
     public void createDataSet() {
         validateConnection(connection);
         validateDataSetConfig(dataSetConfig);
@@ -31,6 +40,12 @@ public class RiderDSL {
         }
     }
 
+    /**
+     * Configures the DSL with provided JDBC connection
+     *
+     * @param connection jdbc connection to be used when populating the database
+     * @return
+     */
     public static DataSetConfigDSL withConnection(Connection connection) {
         createInstance();
         validateConnection(connection);
@@ -40,6 +55,7 @@ public class RiderDSL {
 
     /**
      * Reuses current connection configured in the DSL
+     *
      * @return DataSet config DSL
      */
     public static DataSetConfigDSL withConnection() {
@@ -48,12 +64,23 @@ public class RiderDSL {
 
     public static class DataSetConfigDSL {
 
+        /**
+         * Configures the DSL with provided DataSet configuration
+         *
+         * @param dataSetConfig {@link DataSetConfig}
+         * @return A DBUnitConfigDSL to create DBUnit configuration ({@link DBUnitConfig}
+         */
         public static DBUnitConfigDSL withDataSet(DataSetConfig dataSetConfig) {
             validateDataSetConfig(dataSetConfig);
             INSTANCE.dataSetConfig = dataSetConfig;
             return new DBUnitConfigDSL();
         }
 
+        /**
+         * Reuses dataset configuration already provided to the DSL
+         *
+         * @return A DBUnitConfigDSL to create DBUnit configuration ({@link DBUnitConfig}
+         */
         public static DBUnitConfigDSL withDataSet() {
             return withDataSet(INSTANCE.dataSetConfig);
         }
@@ -62,11 +89,21 @@ public class RiderDSL {
 
     public static class DBUnitConfigDSL {
 
+        /**
+         * Configures the DSL with provided DBUnit configuration
+         *
+         * @param dbUnitConfig {@link DBUnitConfig}
+         * @return
+         */
         public static RiderDSL withDBUnitConfig(DBUnitConfig dbUnitConfig) {
             INSTANCE.dbUnitConfig = dbUnitConfig;
             return INSTANCE;
         }
 
+        /**
+         * Creates a dataset in database using the provided connection ({@link Connection}), dataset configuration ({@link DataSetConfig}
+         * and dbunit configuration ({@link DBUnitConfig})
+         */
         public static void createDataSet() {
             INSTANCE.createDataSet();
         }

--- a/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
@@ -1,7 +1,6 @@
 package com.github.database.rider.core.dsl;
 
 import com.github.database.rider.core.DataSetProviderIt;
-import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.configuration.DBUnitConfig;
 import com.github.database.rider.core.configuration.DataSetConfig;
 import com.github.database.rider.core.model.Follower;
@@ -12,6 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 import java.util.List;
 
 import static com.github.database.rider.core.api.dataset.SeedStrategy.INSERT;

--- a/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
@@ -110,8 +110,8 @@ public class RiderDSLIt {
     }
 
     @Test
-    //@DataSet(value = "yml/lowercaseUsers.yml") // note that hsqldb tables are in uppercase
-    //@DBUnit(caseSensitiveTableNames = false)
+    /*same as: @DataSet(value = "yml/lowercaseUsers.yml") // note that hsqldb tables are in uppercase
+     @DBUnit(caseSensitiveTableNames = false) */
     public void shouldListUsersWithCaseInSensitiveTableNames() {
         RiderDSL.withConnection(emProvider.connection())
                 .withDataSetConfig(new DataSetConfig("yml/lowercaseUsers.yml"))

--- a/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
@@ -1,0 +1,282 @@
+package com.github.database.rider.core.dsl;
+
+import com.github.database.rider.core.DataSetProviderIt;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.configuration.DataSetConfig;
+import com.github.database.rider.core.model.Follower;
+import com.github.database.rider.core.model.User;
+import com.github.database.rider.core.util.EntityManagerProvider;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.List;
+
+import static com.github.database.rider.core.api.dataset.SeedStrategy.INSERT;
+import static com.github.database.rider.core.api.dataset.SeedStrategy.TRUNCATE_INSERT;
+import static com.github.database.rider.core.dsl.RiderDSL.DataSetConfigDSL.withDataSet;
+import static com.github.database.rider.core.util.EntityManagerProvider.em;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class RiderDSLIt {
+
+    @Rule
+    public EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
+
+    @Test
+    public void shouldCreateDataSetUsingDSL() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .createDataSet();
+
+        List<User> users = em().createQuery("select u from User u").getResultList();
+        assertThat(users).hasSize(2)
+                .extracting("name")
+                .contains("@realpestano", "@dbunit");
+
+    }
+
+    @Test
+    public void shouldCreateMultipleDataSetsReusingDSLInstance() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .createDataSet();
+
+        List<User> users = em().createQuery("select u from User u").getResultList();
+        assertThat(users).hasSize(2)
+                .extracting("name")
+                .contains("@realpestano", "@dbunit");
+
+
+        RiderDSL.withConnection()
+                .withDataSet(new DataSetConfig("datasets/yml/empty.yml"))
+                .createDataSet();
+
+        users = em().createQuery("select u from User u").getResultList();
+        assertThat(users).isEmpty();
+
+
+        //you also don't need to use connection dsl if it is already initialized
+        RiderDSL.DataSetConfigDSL
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .createDataSet();
+
+        users = em().createQuery("select u from User u").getResultList();
+        assertThat(users).hasSize(2)
+                .extracting("name")
+                .contains("@realpestano", "@dbunit");
+
+        //you can also use static import if you're sure the connection is initialized
+
+        withDataSet(new DataSetConfig("datasets/yml/empty.yml"))
+                .createDataSet();
+
+        users = em().createQuery("select u from User u").getResultList();
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+  /*  @DataSet(provider = UserDataSetProvider.class,
+            cleanBefore = true)*/
+    public void shouldSeedDatabaseProgrammatically() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProvider.class)
+                     .cleanBefore(true))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
+        assertThat(users).
+                isNotNull().
+                isNotEmpty().hasSize(2).
+                extracting("name").
+                contains("@dbunit", "@dbrider");
+    }
+
+    @Test
+    //@DataSet(provider = UserDataSetProviderWithColumnsSyntax.class)
+    public void shouldSeedDatabaseUsingDataSetProviderWithColumnsSyntax() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProviderWithColumnsSyntax.class)
+                      .cleanBefore(true))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
+        assertThat(users).
+                isNotNull().
+                isNotEmpty().hasSize(2).
+                extracting("name").
+                contains("@dbunit", "@dbrider");
+    }
+
+    @Test
+    //@DataSet(value = "yml/lowercaseUsers.yml") // note that hsqldb tables are in uppercase
+    //@DBUnit(caseSensitiveTableNames = false)
+    public void shouldListUsersWithCaseInSensitiveTableNames() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("yml/lowercaseUsers.yml"))
+                .withDBUnitConfig(new DBUnitConfig().addDBUnitProperty("caseSensitiveTableNames", false))
+                .createDataSet();
+        List<com.github.database.rider.core.model.lowercase.User> users = EntityManagerProvider.em().createQuery("select u from User u").getResultList();
+        assertThat(users).isNotNull().isNotEmpty().hasSize(2);
+    }
+
+    @Test
+    //@DataSet(value = "datasets/yml/user.yml", cleanBefore = true)
+    public void shouldSeedDatabase() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/user.yml")
+                        .cleanBefore(true))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
+        assertThat(users).
+                isNotNull().
+                isNotEmpty().
+                hasSize(2);
+    }
+
+    @Test
+    //@DataSet(value = "datasets/yml/users.yml", executeStatementsBefore = "SET DATABASE REFERENTIAL INTEGRITY FALSE;", executeStatementsAfter = "SET DATABASE REFERENTIAL INTEGRITY TRUE;")
+    public void shouldSeedDataSetDisablingContraintsViaStatement() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                        .executeStatementsBefore("SET DATABASE REFERENTIAL INTEGRITY FALSE;")
+                        .executeStatementsAfter("SET DATABASE REFERENTIAL INTEGRITY TRUE;"))
+                .createDataSet();
+
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u join fetch u.tweets join fetch u.followers join fetch u.tweets join fetch u.followers where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+        assertThat(user.getTweets()).hasSize(1);
+    }
+
+
+    @Test
+    /*@DataSet(value = "datasets/yml/users.yml",
+            useSequenceFiltering = false,
+            tableOrdering = {"USER", "TWEET", "FOLLOWER"},
+            executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})*/
+    public void shouldSeedDataSetUsingTableCreationOrder() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                        .useSequenceFiltering(true)
+                        .tableOrdering("USER", "TWEET", "FOLLOWER")
+                        .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em().createQuery("select u from User u left join fetch u.tweets left join fetch u.followers").getResultList();
+        assertThat(users).hasSize(2);
+    }
+
+    @Test
+    //@DataSet(value = "datasets/yml/users.yml", strategy = SeedStrategy.TRUNCATE_INSERT, useSequenceFiltering = true)
+    public void shouldSeedUserDataSetUsingTruncateInsert() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                        .useSequenceFiltering(true)
+                        .strategy(TRUNCATE_INSERT))
+                .createDataSet();
+        List<User> users = EntityManagerProvider.em("rules-it").createQuery("select u from User u", User.class).getResultList();
+        assertThat(users).isNotNull();
+        assertThat(users.size()).isEqualTo(2);
+        assertThat(users.get(0).getId()).isEqualTo(1);
+        assertThat(users.get(0).getName()).isEqualTo("@realpestano");
+        assertThat(users.get(1).getId()).isEqualTo(2);
+        assertThat(users.get(1).getName()).isEqualTo("@dbunit");
+    }
+
+    @Test
+    //@DataSet(value = "datasets/json/users.json")
+    public void shouldLoadUsersFromJsonDataset() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/json/users.json"))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+        assertThat(user.getTweets()).hasSize(1);
+        Assert.assertEquals("dbunit rules json example", user.getTweets().get(0).getContent());
+        assertThat(user.getFollowers()).isNotNull().hasSize(1);
+        Follower expectedFollower = new Follower(2, 1);
+        assertThat(user.getFollowers()).contains(expectedFollower);
+    }
+
+    @Test
+    //@DataSet(value = "datasets/xml/users.xml")
+    public void shouldLoadUsersFromXmlDataset() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/xml/users.xml"))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+        assertThat(user.getTweets()).hasSize(1);
+        Assert.assertEquals("dbunit rules flat xml example", user.getTweets().get(0).getContent());
+        assertThat(user.getFollowers()).isNotNull().hasSize(1);
+        Follower expectedFollower = new Follower(2, 1);
+        assertThat(user.getFollowers()).contains(expectedFollower);
+    }
+
+    @Test
+    //@DataSet(strategy = SeedStrategy.INSERT, value = {"yml/user.yml", "yml/tweet.yml", "yml/follower.yml"}, executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})
+    public void shouldLoadDataFromMultipleDataSets() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("yml/user.yml","yml/tweet.yml","yml/follower.yml")
+                        .strategy(INSERT)
+                        .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em("rules-it").createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+        assertThat(user.getTweets()).hasSize(1);
+        Assert.assertEquals("dbunit rules again!", user.getTweets().get(0).getContent());
+        assertThat(user.getFollowers()).isNotNull().hasSize(1);
+        Follower expectedFollower = new Follower(2, 1);
+        assertThat(user.getFollowers()).contains(expectedFollower);
+    }
+
+    @Test
+    //@DataSet(strategy = SeedStrategy.INSERT, value = "yml/user.yml, yml/tweet.yml, yml/follower.yml",
+    // executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})
+    public void shouldLoadDataFromMultipleDataSetsUsingCommaToSeparateNames() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("yml/user.yml, yml/tweet.yml, yml/follower.yml")
+                        .strategy(INSERT)
+                        .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em("rules-it").createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+        assertThat(user.getTweets()).hasSize(1);
+        Assert.assertEquals("dbunit rules again!", user.getTweets().get(0).getContent());
+        assertThat(user.getFollowers()).isNotNull().hasSize(1);
+        Follower expectedFollower = new Follower(2, 1);
+        assertThat(user.getFollowers()).contains(expectedFollower);
+    }
+
+
+    @Test
+    //@DataSet(value = "datasets/csv/USER.csv", cleanBefore = true)
+    public void shouldSeedDatabaseWithCSVDataSet() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/csv/USER.csv")
+                        .cleanBefore(true))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u join u.tweets t where t.content = 'dbunit rules!'").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getName()).isEqualTo("@realpestano");
+    }
+
+
+    @Test
+    //@DataSet("xls/users.xls")
+    public void shouldSeedDatabaseWithXLSDataSet() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("xls/users.xls")
+                        .cleanBefore(true))
+                .createDataSet();
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u join u.tweets t where t.content = 'dbunit rules!'").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getName()).isEqualTo("@realpestano");
+    }
+
+}

--- a/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/dsl/RiderDSLIt.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static com.github.database.rider.core.api.dataset.SeedStrategy.INSERT;
 import static com.github.database.rider.core.api.dataset.SeedStrategy.TRUNCATE_INSERT;
-import static com.github.database.rider.core.dsl.RiderDSL.DataSetConfigDSL.withDataSet;
+import static com.github.database.rider.core.dsl.RiderDSL.DataSetConfigDSL.withDataSetConfig;
 import static com.github.database.rider.core.util.EntityManagerProvider.em;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +29,7 @@ public class RiderDSLIt {
     @Test
     public void shouldCreateDataSetUsingDSL() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml"))
                 .createDataSet();
 
         List<User> users = em().createQuery("select u from User u").getResultList();
@@ -42,7 +42,7 @@ public class RiderDSLIt {
     @Test
     public void shouldCreateMultipleDataSetsReusingDSLInstance() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml"))
                 .createDataSet();
 
         List<User> users = em().createQuery("select u from User u").getResultList();
@@ -52,7 +52,7 @@ public class RiderDSLIt {
 
 
         RiderDSL.withConnection()
-                .withDataSet(new DataSetConfig("datasets/yml/empty.yml"))
+                .withDataSetConfig(new DataSetConfig("datasets/yml/empty.yml"))
                 .createDataSet();
 
         users = em().createQuery("select u from User u").getResultList();
@@ -61,7 +61,7 @@ public class RiderDSLIt {
 
         //you also don't need to use connection dsl if it is already initialized
         RiderDSL.DataSetConfigDSL
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml"))
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml"))
                 .createDataSet();
 
         users = em().createQuery("select u from User u").getResultList();
@@ -71,7 +71,7 @@ public class RiderDSLIt {
 
         //you can also use static import if you're sure the connection is initialized
 
-        withDataSet(new DataSetConfig("datasets/yml/empty.yml"))
+        withDataSetConfig(new DataSetConfig("datasets/yml/empty.yml"))
                 .createDataSet();
 
         users = em().createQuery("select u from User u").getResultList();
@@ -83,7 +83,7 @@ public class RiderDSLIt {
             cleanBefore = true)*/
     public void shouldSeedDatabaseProgrammatically() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProvider.class)
+                .withDataSetConfig(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProvider.class)
                      .cleanBefore(true))
                 .createDataSet();
         List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
@@ -98,7 +98,7 @@ public class RiderDSLIt {
     //@DataSet(provider = UserDataSetProviderWithColumnsSyntax.class)
     public void shouldSeedDatabaseUsingDataSetProviderWithColumnsSyntax() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProviderWithColumnsSyntax.class)
+                .withDataSetConfig(new DataSetConfig().datasetProvider(DataSetProviderIt.UserDataSetProviderWithColumnsSyntax.class)
                       .cleanBefore(true))
                 .createDataSet();
         List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
@@ -114,7 +114,7 @@ public class RiderDSLIt {
     //@DBUnit(caseSensitiveTableNames = false)
     public void shouldListUsersWithCaseInSensitiveTableNames() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("yml/lowercaseUsers.yml"))
+                .withDataSetConfig(new DataSetConfig("yml/lowercaseUsers.yml"))
                 .withDBUnitConfig(new DBUnitConfig().addDBUnitProperty("caseSensitiveTableNames", false))
                 .createDataSet();
         List<com.github.database.rider.core.model.lowercase.User> users = EntityManagerProvider.em().createQuery("select u from User u").getResultList();
@@ -125,7 +125,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/yml/user.yml", cleanBefore = true)
     public void shouldSeedDatabase() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/user.yml")
+                .withDataSetConfig(new DataSetConfig("datasets/yml/user.yml")
                         .cleanBefore(true))
                 .createDataSet();
         List<User> users = EntityManagerProvider.em().createQuery("select u from User u ").getResultList();
@@ -139,7 +139,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/yml/users.yml", executeStatementsBefore = "SET DATABASE REFERENTIAL INTEGRITY FALSE;", executeStatementsAfter = "SET DATABASE REFERENTIAL INTEGRITY TRUE;")
     public void shouldSeedDataSetDisablingContraintsViaStatement() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml")
                         .executeStatementsBefore("SET DATABASE REFERENTIAL INTEGRITY FALSE;")
                         .executeStatementsAfter("SET DATABASE REFERENTIAL INTEGRITY TRUE;"))
                 .createDataSet();
@@ -158,7 +158,7 @@ public class RiderDSLIt {
             executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})*/
     public void shouldSeedDataSetUsingTableCreationOrder() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml")
                         .useSequenceFiltering(true)
                         .tableOrdering("USER", "TWEET", "FOLLOWER")
                         .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
@@ -171,7 +171,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/yml/users.yml", strategy = SeedStrategy.TRUNCATE_INSERT, useSequenceFiltering = true)
     public void shouldSeedUserDataSetUsingTruncateInsert() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/users.yml")
+                .withDataSetConfig(new DataSetConfig("datasets/yml/users.yml")
                         .useSequenceFiltering(true)
                         .strategy(TRUNCATE_INSERT))
                 .createDataSet();
@@ -188,7 +188,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/json/users.json")
     public void shouldLoadUsersFromJsonDataset() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/json/users.json"))
+                .withDataSetConfig(new DataSetConfig("datasets/json/users.json"))
                 .createDataSet();
         User user = (User) EntityManagerProvider.em().createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
         assertThat(user).isNotNull();
@@ -204,7 +204,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/xml/users.xml")
     public void shouldLoadUsersFromXmlDataset() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/xml/users.xml"))
+                .withDataSetConfig(new DataSetConfig("datasets/xml/users.xml"))
                 .createDataSet();
         User user = (User) EntityManagerProvider.em().createQuery("select u from User u join fetch u.tweets join fetch u.followers left join fetch u.followers where u.id = 1").getSingleResult();
         assertThat(user).isNotNull();
@@ -220,7 +220,7 @@ public class RiderDSLIt {
     //@DataSet(strategy = SeedStrategy.INSERT, value = {"yml/user.yml", "yml/tweet.yml", "yml/follower.yml"}, executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})
     public void shouldLoadDataFromMultipleDataSets() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("yml/user.yml","yml/tweet.yml","yml/follower.yml")
+                .withDataSetConfig(new DataSetConfig("yml/user.yml","yml/tweet.yml","yml/follower.yml")
                         .strategy(INSERT)
                         .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
                 .createDataSet();
@@ -239,7 +239,7 @@ public class RiderDSLIt {
     // executeStatementsBefore = {"DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"})
     public void shouldLoadDataFromMultipleDataSetsUsingCommaToSeparateNames() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("yml/user.yml, yml/tweet.yml, yml/follower.yml")
+                .withDataSetConfig(new DataSetConfig("yml/user.yml, yml/tweet.yml, yml/follower.yml")
                         .strategy(INSERT)
                         .executeStatementsBefore("DELETE FROM FOLLOWER", "DELETE FROM TWEET", "DELETE FROM USER"))
                 .createDataSet();
@@ -258,7 +258,7 @@ public class RiderDSLIt {
     //@DataSet(value = "datasets/csv/USER.csv", cleanBefore = true)
     public void shouldSeedDatabaseWithCSVDataSet() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/csv/USER.csv")
+                .withDataSetConfig(new DataSetConfig("datasets/csv/USER.csv")
                         .cleanBefore(true))
                 .createDataSet();
         User user = (User) EntityManagerProvider.em().createQuery("select u from User u join u.tweets t where t.content = 'dbunit rules!'").getSingleResult();
@@ -271,7 +271,7 @@ public class RiderDSLIt {
     //@DataSet("xls/users.xls")
     public void shouldSeedDatabaseWithXLSDataSet() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("xls/users.xls")
+                .withDataSetConfig(new DataSetConfig("xls/users.xls")
                         .cleanBefore(true))
                 .createDataSet();
         User user = (User) EntityManagerProvider.em().createQuery("select u from User u join u.tweets t where t.content = 'dbunit rules!'").getSingleResult();

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
@@ -35,7 +35,7 @@ public class CustomReplacementIt {
     @Test
     public void shouldReplaceFooUsingRiderDSL() {
         RiderDSL.withConnection(emProvider.connection())
-                .withDataSet(new DataSetConfig("datasets/yml/custom-replacements.yml")
+                .withDataSetConfig(new DataSetConfig("datasets/yml/custom-replacements.yml")
                          .disableConstraints(true))
                 .withDBUnitConfig(new DBUnitConfig().addDBUnitProperty("replacers", Arrays.asList(new CustomReplacer())))
                 .createDataSet();

--- a/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/replacers/CustomReplacementIt.java
@@ -3,10 +3,15 @@ package com.github.database.rider.core.replacers;
 import com.github.database.rider.core.DBUnitRule;
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.configuration.DataSetConfig;
+import com.github.database.rider.core.dsl.RiderDSL;
 import com.github.database.rider.core.model.Tweet;
 import com.github.database.rider.core.util.EntityManagerProvider;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,4 +31,17 @@ public class CustomReplacementIt {
         assertThat(tweet).isNotNull();
         assertThat(tweet.getContent()).isNotNull().isEqualTo("BAR");
     }
+
+    @Test
+    public void shouldReplaceFooUsingRiderDSL() {
+        RiderDSL.withConnection(emProvider.connection())
+                .withDataSet(new DataSetConfig("datasets/yml/custom-replacements.yml")
+                         .disableConstraints(true))
+                .withDBUnitConfig(new DBUnitConfig().addDBUnitProperty("replacers", Arrays.asList(new CustomReplacer())))
+                .createDataSet();
+        Tweet tweet = (Tweet) EntityManagerProvider.em().createQuery("select t from Tweet t where t.id = '1'").getSingleResult();
+        assertThat(tweet).isNotNull();
+        assertThat(tweet.getContent()).isNotNull().isEqualTo("BAR");
+    }
+
 }


### PR DESCRIPTION
This is an attempt on creating a DSL to create datasets instead of using annotations.

The annotation approach is great and does a good job separating test configuration from test logic. 

The main issue with annotation approach is that it is dependent on the test run engine which reads the annotation and then creates the dataset.

So for example, if you use cucumber you cannot use annotation approach and have to deal with DataSetExecutor directly which is not so fluent API.

Also, the annotations will not help when dealing with multiple databases on the [same test](https://github.com/database-rider/database-rider/blob/d02c236c2e59fef336c39bc78de6872f0ce63f5e/rider-core/src/test/java/com/github/database/rider/core/MultipleDataBasesIt.java#L45), you can only specify an executor ID per test when using annotations.



