### PR TITLE
Disable foreign key constraint violation when cleaning database

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -601,6 +601,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
      */
     @Override
     public void clearDatabase(DataSetConfig config) throws SQLException {
+        disableConstraints();
         Connection connection = getRiderDataSource().getConnection();
         if (config != null && config.getTableOrdering() != null && config.getTableOrdering().length > 0) {
             for (String table : config.getTableOrdering()) {
@@ -638,6 +639,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                         + e.getCause());
             }
         }
+        enableConstraints();
 
     }
 

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -641,7 +641,11 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                         + e.getCause());
             }
         }
-        enableConstraints();
+
+        // enabling constraints only if `disableConstraints == false`
+        if(!config.isDisableConstraints()) {
+            enableConstraints();
+        }
 
     }
 


### PR DESCRIPTION
This pull-request is for issue https://github.com/database-rider/database-rider/issues/202.

* Decorating the [com.github.database.rider.core.dataset.DataSetExecutorImpl#clearDatabase](https://github.com/database-rider/database-rider/blob/master/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java#L603) method with [disableConstraints()](https://github.com/database-rider/database-rider/blob/b03cf80002ab82e7f918aa56aa8852896f3bac77/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java#L326) call before and with [enableConstraints()](https://github.com/database-rider/database-rider/blob/master/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java#L389) call after.