### PR TITLE
Removing Suspicious Comments

### DIFF
--- a/rider-cdi/src/test/java/com/github/database/rider/cdi/DBUnitCDIIt.java
+++ b/rider-cdi/src/test/java/com/github/database/rider/cdi/DBUnitCDIIt.java
@@ -132,9 +132,4 @@ public class DBUnitCDIIt {
 
 
 
-
-    //TODO replacer test
-    //TODO execute scripts after test
-    //TODO disable constraints
-
 }


### PR DESCRIPTION
According to the Common Weakness Enumeration organization, this is a security weakness([CWE-546](https://cwe.mitre.org/data/definitions/546.html): Suspicious Comment). The comments in your code can help malicious users to find the potential presence of a bug, incomplete functionality, or weaknesses to attack the system.