### PR TITLE
Add a remark to use encrypted passwords only

### DIFF
--- a/rider-examples/quarkus-dbunit-sample/src/main/resources/application.properties
+++ b/rider-examples/quarkus-dbunit-sample/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.http.auth.form.landing-page=http://localhost:8080
 quarkus.datasource.url = jdbc:postgresql://localhost:5432/cdbookstoreDB
 quarkus.datasource.driver = org.postgresql.Driver
 quarkus.datasource.username = cdbookstoreDB
+# unencrypted password is fine for the showcase but don't do it in a real application!
 quarkus.datasource.password = h2g2
 quarkus.datasource.max-size=20
 quarkus.datasource.min-size=5


### PR DESCRIPTION
Hard coded passwords are bad. But the examples are show cases only which should be easy to read.

Closes #218 