### PR TITLE
Feature request: Limit the database type. #227

### DIFF
--- a/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
@@ -1,11 +1,10 @@
 package com.github.database.rider.spring;
 
-import com.github.database.rider.core.RiderRunner;
-import com.github.database.rider.core.RiderTestContext;
-import com.github.database.rider.core.connection.RiderDataSource;
-import com.github.database.rider.spring.api.DBRider;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import com.github.database.rider.core.RiderRunner;
+import com.github.database.rider.core.RiderTestContext;
 
 /**
  * {@link org.springframework.test.context.TestExecutionListener TestExecutionListener}
@@ -24,21 +23,15 @@ public class DBRiderTestExecutionListener extends AbstractTestExecutionListener 
         RiderRunner riderRunner = new RiderRunner();
         riderRunner.setup(riderTestContext);
         riderRunner.runBeforeTest(riderTestContext);
-        DBRider dbRiderAnnotation = testContext.getTestMethod().getAnnotation(DBRider.class);
-        if(dbRiderAnnotation == null) {
-            testContext.getTestClass().getAnnotation(DBRider.class);
-        }
-        RiderDataSource.DBType contextDBType = riderTestContext.getDataSetExecutor().getRiderDataSource().getDBType();
-        if (dbRiderAnnotation != null && dbRiderAnnotation.dataBaseType() != RiderDataSource.DBType.UNKNOWN && dbRiderAnnotation.dataBaseType() != contextDBType) {
-            throw new IllegalArgumentException(String.format("Expect %s database instead of %s database.", dbRiderAnnotation.dataBaseType(), contextDBType));
-        }
     }
 
     @Override
     public void afterTestMethod(TestContext testContext) throws Exception {
         RiderTestContext riderTestContext = (RiderTestContext) testContext.getAttribute(RIDER_TEST_CONTEXT);
+        if (riderTestContext == null) {
+            return;
+        }
         RiderRunner riderRunner = new RiderRunner();
-
         try {
             riderRunner.runAfterTest(riderTestContext);
         } finally {

--- a/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
@@ -2,6 +2,8 @@ package com.github.database.rider.spring;
 
 import com.github.database.rider.core.RiderRunner;
 import com.github.database.rider.core.RiderTestContext;
+import com.github.database.rider.core.connection.RiderDataSource;
+import com.github.database.rider.spring.api.DBRider;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
@@ -19,10 +21,14 @@ public class DBRiderTestExecutionListener extends AbstractTestExecutionListener 
     public void beforeTestMethod(TestContext testContext) throws Exception {
         RiderTestContext riderTestContext = SpringRiderTestContext.create(testContext);
         testContext.setAttribute(RIDER_TEST_CONTEXT, riderTestContext);
-
         RiderRunner riderRunner = new RiderRunner();
         riderRunner.setup(riderTestContext);
         riderRunner.runBeforeTest(riderTestContext);
+        DBRider dbRiderAnnotation = testContext.getTestMethod().getAnnotation(DBRider.class);
+        RiderDataSource.DBType contextDBType = riderTestContext.getDataSetExecutor().getRiderDataSource().getDBType();
+        if (dbRiderAnnotation.dataBaseType() != RiderDataSource.DBType.UNKNOWN && dbRiderAnnotation.dataBaseType() != contextDBType) {
+            throw new IllegalArgumentException(String.format("Expect %s database instead of %s database.", dbRiderAnnotation.dataBaseType(), contextDBType));
+        }
     }
 
     @Override

--- a/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/DBRiderTestExecutionListener.java
@@ -25,8 +25,11 @@ public class DBRiderTestExecutionListener extends AbstractTestExecutionListener 
         riderRunner.setup(riderTestContext);
         riderRunner.runBeforeTest(riderTestContext);
         DBRider dbRiderAnnotation = testContext.getTestMethod().getAnnotation(DBRider.class);
+        if(dbRiderAnnotation == null) {
+            testContext.getTestClass().getAnnotation(DBRider.class);
+        }
         RiderDataSource.DBType contextDBType = riderTestContext.getDataSetExecutor().getRiderDataSource().getDBType();
-        if (dbRiderAnnotation.dataBaseType() != RiderDataSource.DBType.UNKNOWN && dbRiderAnnotation.dataBaseType() != contextDBType) {
+        if (dbRiderAnnotation != null && dbRiderAnnotation.dataBaseType() != RiderDataSource.DBType.UNKNOWN && dbRiderAnnotation.dataBaseType() != contextDBType) {
             throw new IllegalArgumentException(String.format("Expect %s database instead of %s database.", dbRiderAnnotation.dataBaseType(), contextDBType));
         }
     }

--- a/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.github.database.rider.core.connection.RiderDataSource;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.test.context.TestExecutionListeners;
 
 import com.github.database.rider.spring.DBRiderTestExecutionListener;
@@ -25,5 +27,13 @@ public @interface DBRider {
    * @return name of the DataSource bean in Spring Context.
    * If empty then dataSource bean will be loaded by class and thus default one will be used.
    */
+  @AliasFor("value")
   String dataSourceBeanName() default "";
+
+  /**
+   * @return the expected database type.
+   * If empty then do not validate database type.
+   * @throws IllegalArgumentException If the expected database type different from that of context.
+   */
+  RiderDataSource.DBType dataBaseType() default RiderDataSource.DBType.UNKNOWN;
 }

--- a/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
@@ -6,7 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import com.github.database.rider.core.connection.RiderDataSource;
-import org.springframework.core.annotation.AliasFor;
 import org.springframework.test.context.TestExecutionListeners;
 
 import com.github.database.rider.spring.DBRiderTestExecutionListener;
@@ -27,7 +26,6 @@ public @interface DBRider {
    * @return name of the DataSource bean in Spring Context.
    * If empty then dataSource bean will be loaded by class and thus default one will be used.
    */
-  @AliasFor("value")
   String dataSourceBeanName() default "";
 
   /**

--- a/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
@@ -5,10 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.github.database.rider.core.connection.RiderDataSource;
 import org.springframework.test.context.TestExecutionListeners;
 
 import com.github.database.rider.spring.DBRiderTestExecutionListener;
+import com.github.database.rider.core.connection.RiderDataSource;
 
 /**
  * Shortcut to enable database rider tests.

--- a/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
+++ b/rider-spring/src/main/java/com/github/database/rider/spring/api/DBRider.java
@@ -30,8 +30,8 @@ public @interface DBRider {
 
   /**
    * @return the expected database type.
-   * If empty then do not validate database type.
+   * If use {@link RiderDataSource.DBType#UNKNOWN}, database type will not be validated.
    * @throws IllegalArgumentException If the expected database type different from that of context.
    */
-  RiderDataSource.DBType dataBaseType() default RiderDataSource.DBType.UNKNOWN;
+  RiderDataSource.DBType databaseType() default RiderDataSource.DBType.UNKNOWN;
 }

--- a/rider-spring/src/test/java/com/github/database/rider/spring/SpringRiderTestContextTest.java
+++ b/rider-spring/src/test/java/com/github/database/rider/spring/SpringRiderTestContextTest.java
@@ -1,0 +1,106 @@
+package com.github.database.rider.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.ClassUtils;
+
+import com.github.database.rider.core.connection.RiderDataSource;
+import com.github.database.rider.spring.api.DBRider;
+import com.github.database.rider.spring.config.TestConfig;
+
+/**
+ * @author kerraway
+ * @date 2020/07/23
+ * @see SpringRiderTestContext
+ */
+public class SpringRiderTestContextTest {
+    @Test
+    public void useDefaultDataSourceByClassConfiguration() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useDefaultDataSourceByClassConfiguration", "default");
+    }
+
+    @Test
+    public void useDefaultDataSource() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useDefaultDataSource", "default");
+    }
+
+    @Test
+    public void useDefaultDataSourceAndRequireHsqldb() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useDefaultDataSourceAndRequireHsqldb", "default");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void useDefaultDataSourceAndRequireH2() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useDefaultDataSourceAndRequireH2", null);
+    }
+
+    @Test
+    public void useSecondDataSource() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useSecondDataSource", "data-source-2");
+    }
+
+    @Test
+    public void useSecondDataSourceAndRequireHsqldb() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useSecondDataSourceAndRequireHsqldb", "data-source-2");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void useSecondDataSourceAndRequireH2() throws Exception {
+        createRiderTestContextAndAssertExecutorId("useSecondDataSourceAndRequireH2", null);
+    }
+
+    private void createRiderTestContextAndAssertExecutorId(String methodName, String expectedExecutorId) throws Exception {
+        TestContext testContext = getTestContext(new DbRiderUsage(), methodName);
+
+        SpringRiderTestContext riderTestContext = SpringRiderTestContext.create(testContext);
+
+        assertNotNull(riderTestContext);
+        assertEquals(expectedExecutorId, riderTestContext.getDataSetExecutor().getExecutorId());
+    }
+
+    private TestContext getTestContext(Object instance, String methodName) throws Exception {
+        TestContextManager testContextManager = new TestContextManager(instance.getClass());
+        testContextManager.prepareTestInstance(instance);
+        testContextManager.beforeTestMethod(instance, ClassUtils.getMethod(instance.getClass(), methodName));
+        return testContextManager.getTestContext();
+    }
+
+    @DBRider
+    @RunWith(SpringRunner.class)
+    @ContextConfiguration(classes = TestConfig.class)
+    static class DbRiderUsage {
+        public void useDefaultDataSourceByClassConfiguration() {
+        }
+
+        @DBRider
+        public void useDefaultDataSource() {
+        }
+
+        @DBRider(databaseType = RiderDataSource.DBType.HSQLDB)
+        public void useDefaultDataSourceAndRequireHsqldb() {
+        }
+
+        @DBRider(databaseType = RiderDataSource.DBType.H2)
+        public void useDefaultDataSourceAndRequireH2() {
+        }
+
+        @DBRider(dataSourceBeanName = "data-source-2")
+        public void useSecondDataSource() {
+        }
+
+        @DBRider(dataSourceBeanName = "data-source-2", databaseType = RiderDataSource.DBType.HSQLDB)
+        public void useSecondDataSourceAndRequireHsqldb() {
+        }
+
+        @DBRider(dataSourceBeanName = "data-source-2", databaseType = RiderDataSource.DBType.H2)
+        public void useSecondDataSourceAndRequireH2() {
+        }
+    }
+}

--- a/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MultipleDataSourcesIT.java
+++ b/rider-spring/src/test/java/com/github/database/rider/spring/dataset/MultipleDataSourcesIT.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.connection.RiderDataSource;
 import com.github.database.rider.spring.api.DBRider;
 import com.github.database.rider.spring.config.TestConfig;
 import com.github.database.rider.spring.model.EntityUtils;
@@ -63,5 +64,15 @@ public class MultipleDataSourcesIT {
         assertThat(actual).containsExactlyElementsOf(expected);
     }
 
+    @Test
+    @DataSet(value = "test.yml")
+    @DBRider(dataBaseType = RiderDataSource.DBType.HSQLDB)
+    public void shouldUseDefaultDataSourceAndTypeCheck() {
+        jdbcTemplate = new JdbcTemplate(defaultDataSource);
+        Set<String> expected = new HashSet<>(Arrays.asList("value1", "value2"));
+        Set<String> actual = new HashSet<>(jdbcTemplate.queryForList("SELECT value FROM Entity", String.class));
+
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
 
 }


### PR DESCRIPTION
Add #databaseType() method into DBRider annotation.

If user configure the #databaseType(), database type will be validated, and RiderDataSource.DBType#UNKNOWN will be ignored.

Ps, Unit test `com.github.database.rider.spring.dataset.MultipleDataSourcesIT` has been updated.

Close #227 .