### PR TITLE
Feature request: Limit the database type. #227

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -342,6 +342,7 @@ leakHunter: false
 mergeDataSets: false
 caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'UPPERCASE' <1>
 raiseExceptionOnCleanUp: false <2>
+expectedDbType: UNKNOWN <3>
 properties:
   batchedStatements:  false
   qualifiedTableNames: false
@@ -352,7 +353,7 @@ properties:
   allowEmptyFields: false
   escapePattern:
   schema:
-  datatypeFactory: !!com.github.database.rider.core.configuration.DBUnitConfigTest$MockDataTypeFactory {} <3>
+  datatypeFactory: !!com.github.database.rider.core.configuration.DBUnitConfigTest$MockDataTypeFactory {} <4>
 connectionConfig:
   driver: ""
   url: ""
@@ -361,7 +362,8 @@ connectionConfig:
 ----
 <1> Only applied when `caseSensitiveTableNames` is `false`. Valid values are `UPPERCASE` and `LOWERCASE`.
 <2> If enabled an exception will be raised when `cleanBefore` or `cleanAfter` fails. If disabled then only a warn message is logged. Default is false.
-<3> Make it possible to define a datatype factory, https://github.com/database-rider/database-rider/issues/30[see issue #30^] for details.
+<3> In the process of initialization, if the actual database type is different from the expected database type, exception will be thrown unless the expected database type is UNKNOWN. Default is UNKNOWN.
+<4> Make it possible to define a datatype factory, https://github.com/database-rider/database-rider/issues/30[see issue #30^] for details.
 
 IMPORTANT: `@DBUnit` annotation takes precedence over `dbunit.yml` global configuration which will be used only if the annotation is not present.
 

--- a/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/configuration/DBUnit.java
@@ -1,5 +1,6 @@
 package com.github.database.rider.core.api.configuration;
 
+import com.github.database.rider.core.connection.RiderDataSource;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 import com.github.database.rider.core.replacers.Replacer;
 
@@ -62,6 +63,17 @@ public @interface DBUnit {
      * @return boolean value which configures case-sensitive table names (also columns)
      */
     boolean raiseExceptionOnCleanUp() default false;
+
+    /**
+     * In the process of initialization, if the actual database type is different from the expected database type,
+     * exception will be thrown unless the expected database type is {@link RiderDataSource.DBType#UNKNOWN}.
+     * <p>
+     * Default is {@link RiderDataSource.DBType#UNKNOWN}.
+     *
+     * @return the expected database type.
+     * @since 1.16.0
+     */
+    RiderDataSource.DBType expectedDbType() default RiderDataSource.DBType.UNKNOWN;
 
     /**
      * @return value which configures DatabaseConfig.PROPERTY_DATATYPE_FACTORY

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
@@ -2,6 +2,7 @@ package com.github.database.rider.core.configuration;
 
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.configuration.Orthography;
+import com.github.database.rider.core.connection.RiderDataSource;
 import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 import com.github.database.rider.core.replacers.DateTimeReplacer;
 import com.github.database.rider.core.replacers.NullReplacer;
@@ -30,6 +31,7 @@ public class DBUnitConfig {
     private Boolean columnSensing;
     private Boolean raiseExceptionOnCleanUp;
     private Orthography caseInsensitiveStrategy;
+    private RiderDataSource.DBType expectedDbType;
     private Map<String, Object> properties;
     private ConnectionConfig connectionConfig;
 
@@ -54,6 +56,7 @@ public class DBUnitConfig {
         mergeDataSets = Boolean.FALSE;
         columnSensing = Boolean.FALSE;
         raiseExceptionOnCleanUp = Boolean.FALSE;
+        expectedDbType = RiderDataSource.DBType.UNKNOWN;
         initDefaultProperties();
         initDefaultConnectionConfig();
     }
@@ -122,13 +125,13 @@ public class DBUnitConfig {
                 .mergeDataSets(dbUnit.mergeDataSets())
                 .columnSensing(dbUnit.columnSensing())
                 .raiseExceptionOnCleanUp(dbUnit.raiseExceptionOnCleanUp())
+                .expectedDbType(dbUnit.expectedDbType())
                 .addDBUnitProperty("batchedStatements", dbUnit.batchedStatements())
                 .addDBUnitProperty("batchSize", dbUnit.batchSize())
                 .addDBUnitProperty("allowEmptyFields", dbUnit.allowEmptyFields())
                 .addDBUnitProperty("fetchSize", dbUnit.fetchSize())
                 .addDBUnitProperty("qualifiedTableNames", dbUnit.qualifiedTableNames())
-                .addDBUnitProperty("schema",
-                        dbUnit.schema() != null && !dbUnit.schema().isEmpty() ? dbUnit.schema() : null)
+                .addDBUnitProperty("schema", !dbUnit.schema().isEmpty() ? dbUnit.schema() : null)
                 .addDBUnitProperty("caseSensitiveTableNames", dbUnit.caseSensitiveTableNames())
                 .caseInsensitiveStrategy(dbUnit.caseInsensitiveStrategy());
 
@@ -265,6 +268,11 @@ public class DBUnitConfig {
         return this;
     }
 
+    public DBUnitConfig expectedDbType(RiderDataSource.DBType expectedDbType) {
+        this.expectedDbType = expectedDbType;
+        return this;
+    }
+
     public ConnectionConfig getConnectionConfig() {
         return connectionConfig;
     }
@@ -345,5 +353,13 @@ public class DBUnitConfig {
 
     public void setRaiseExceptionOnCleanUp(boolean raiseExceptionOnCleanUp) {
         this.raiseExceptionOnCleanUp = raiseExceptionOnCleanUp;
+    }
+
+    public RiderDataSource.DBType getExpectedDbType() {
+        return expectedDbType;
+    }
+
+    public void setExpectedDbType(RiderDataSource.DBType expectedDbType) {
+        this.expectedDbType = expectedDbType;
     }
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/connection/RiderDataSource.java
@@ -70,6 +70,10 @@ public class RiderDataSource {
         Connection conn = getConnection();
         if (conn != null) {
             dbType = resolveDBType(DriverUtils.getDriverName(conn));
+            if (dbUnitConfig.getExpectedDbType() != DBType.UNKNOWN && dbUnitConfig.getExpectedDbType() != dbType) {
+                throw new SQLException(String.format("Expect %s database, but actually %s database.",
+                        dbUnitConfig.getExpectedDbType(), dbType));
+            }
             initDBUnitConnection();
         }
     }

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -190,8 +190,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
             for (Entry<String, Object> entry : dbUnitConfig.getProperties().entrySet()) {
                 sb.append(entry.getKey()).append(": ").append(entry.getValue() == null ? "" : entry.getValue()).append("\n");
             }
-            log.info(String.format("DBUnit configuration for dataset executor '%s':\n" + sb.toString(),
-                    this.executorId));
+            log.info("DBUnit configuration for dataset executor '{}':{}", this.executorId, sb.toString());
         }
     }
 

--- a/rider-core/src/test/java/com/github/database/rider/core/configuration/DBUnitConfigTest.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/configuration/DBUnitConfigTest.java
@@ -2,6 +2,7 @@ package com.github.database.rider.core.configuration;
 
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.core.api.configuration.Orthography;
+import com.github.database.rider.core.connection.RiderDataSource;
 import com.github.database.rider.core.replacers.CustomReplacer;
 import org.dbunit.database.IMetadataHandler;
 import org.dbunit.dataset.datatype.DataType;
@@ -46,6 +47,7 @@ public class DBUnitConfigTest {
                 .hasFieldOrPropertyWithValue("cacheTableNames", true)
                 .hasFieldOrPropertyWithValue("leakHunter", false)
                 .hasFieldOrPropertyWithValue("raiseExceptionOnCleanUp", false)
+                .hasFieldOrPropertyWithValue("expectedDbType", RiderDataSource.DBType.UNKNOWN)
                 .hasFieldOrPropertyWithValue("caseInsensitiveStrategy", Orthography.UPPERCASE);
 
         assertThat(config.getProperties()).
@@ -84,6 +86,7 @@ public class DBUnitConfigTest {
                 .hasFieldOrPropertyWithValue("cacheTableNames", false)
                 .hasFieldOrPropertyWithValue("leakHunter", true)
                 .hasFieldOrPropertyWithValue("raiseExceptionOnCleanUp", true)
+                .hasFieldOrPropertyWithValue("expectedDbType", RiderDataSource.DBType.HSQLDB)
                 .hasFieldOrPropertyWithValue("caseInsensitiveStrategy", Orthography.UPPERCASE);
 
         assertThat(config.getProperties()).
@@ -109,6 +112,7 @@ public class DBUnitConfigTest {
                 .hasFieldOrPropertyWithValue("cacheTableNames", true)
                 .hasFieldOrPropertyWithValue("leakHunter", true)
                 .hasFieldOrPropertyWithValue("raiseExceptionOnCleanUp", false)
+                .hasFieldOrPropertyWithValue("expectedDbType", RiderDataSource.DBType.UNKNOWN)
                 .hasFieldOrPropertyWithValue("caseInsensitiveStrategy", Orthography.UPPERCASE);
 
         assertThat(config.getProperties()).
@@ -122,7 +126,8 @@ public class DBUnitConfigTest {
     }
 
     @Test
-    @DBUnit(cacheTableNames = false, allowEmptyFields = true, batchSize = 50, schema = "public")
+    @DBUnit(cacheTableNames = false, allowEmptyFields = true, batchSize = 50, schema = "public",
+            expectedDbType = RiderDataSource.DBType.HSQLDB)
     public void shouldLoadDBUnitConfigViaAnnotation() throws NoSuchMethodException {
         Method method = getClass().getMethod("shouldLoadDBUnitConfigViaAnnotation");
         DBUnit dbUnit = method.getAnnotation(DBUnit.class);
@@ -130,7 +135,8 @@ public class DBUnitConfigTest {
 
         assertThat(dbUnitConfig).isNotNull()
                 .hasFieldOrPropertyWithValue("cacheConnection", true)
-                .hasFieldOrPropertyWithValue("cacheTableNames", false);
+                .hasFieldOrPropertyWithValue("cacheTableNames", false)
+                .hasFieldOrPropertyWithValue("expectedDbType", RiderDataSource.DBType.HSQLDB);
 
         assertThat(dbUnitConfig.getProperties()).
                 containsEntry("allowEmptyFields", true).

--- a/rider-core/src/test/java/com/github/database/rider/core/connection/RiderDataSourceIT.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/connection/RiderDataSourceIT.java
@@ -1,0 +1,111 @@
+package com.github.database.rider.core.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.connection.ConnectionHolder;
+import com.github.database.rider.core.configuration.DBUnitConfig;
+import com.github.database.rider.core.configuration.GlobalConfig;
+import com.github.database.rider.core.util.EntityManagerProvider;
+
+/**
+ * @author kerraway
+ * @date 2020/07/24
+ * @see RiderDataSource
+ */
+@RunWith(JUnit4.class)
+public class RiderDataSourceIT {
+
+    @Rule
+    public final EntityManagerProvider emProvider = EntityManagerProvider.instance("rules-it");
+
+    private File customConfigFile;
+
+    @Before
+    public void setUp() {
+        customConfigFile = new File("target/test-classes/dbunit.yml");
+    }
+
+    @After
+    public void tearDown() {
+        if (customConfigFile != null) {
+            customConfigFile.delete();
+        }
+    }
+
+    @Test
+    public void shouldInitDBUnitConfigWithDefaultValues() {
+        DBUnitConfig dbUnitConfig = GlobalConfig.newInstance().getDbUnitConfig();
+
+        createRiderDataSourceAndAssertDbType(dbUnitConfig);
+    }
+
+    @Test
+    public void shouldLoadDBUnitConfigViaCustomGlobalFile() throws IOException {
+        copyResourceToFile("/config/sample-dbunit.yml", customConfigFile);
+        DBUnitConfig dbUnitConfig = GlobalConfig.newInstance().getDbUnitConfig();
+
+        createRiderDataSourceAndAssertDbType(dbUnitConfig);
+    }
+
+    @Test
+    public void shouldMergeDBUnitConfigViaCustomGlobalFile() throws IOException {
+        copyResourceToFile("/config/merge-dbunit.yml", customConfigFile);
+        DBUnitConfig dbUnitConfig = GlobalConfig.newInstance().getDbUnitConfig();
+
+        createRiderDataSourceAndAssertDbType(dbUnitConfig);
+    }
+
+    @Test
+    @DBUnit(expectedDbType = RiderDataSource.DBType.HSQLDB)
+    public void shouldLoadDBUnitConfigViaAnnotation() throws NoSuchMethodException {
+        Method method = getClass().getMethod("shouldLoadDBUnitConfigViaAnnotation");
+        DBUnit dbUnit = method.getAnnotation(DBUnit.class);
+        DBUnitConfig dbUnitConfig = DBUnitConfig.from(dbUnit);
+
+        createRiderDataSourceAndAssertDbType(dbUnitConfig);
+    }
+
+    @Test(expected = RuntimeException.class)
+    @DBUnit(expectedDbType = RiderDataSource.DBType.H2)
+    public void shouldLoadDBUnitConfigViaAnnotationWithWrongDbType() throws NoSuchMethodException {
+        Method method = getClass().getMethod("shouldLoadDBUnitConfigViaAnnotationWithWrongDbType");
+        DBUnit dbUnit = method.getAnnotation(DBUnit.class);
+        DBUnitConfig dbUnitConfig = DBUnitConfig.from(dbUnit);
+
+        createRiderDataSourceAndAssertDbType(dbUnitConfig);
+    }
+
+    private void createRiderDataSourceAndAssertDbType(final DBUnitConfig dbUnitConfig) {
+        RiderDataSource riderDataSource = new RiderDataSource(new ConnectionHolder() {
+            @Override
+            public Connection getConnection() throws SQLException {
+                return emProvider.connection();
+            }
+        }, dbUnitConfig);
+
+        assertThat(riderDataSource).isNotNull()
+                .hasFieldOrPropertyWithValue("dbType", RiderDataSource.DBType.HSQLDB);
+    }
+
+    private void copyResourceToFile(String resourceName, File to) throws IOException {
+        try (InputStream from = getClass().getResourceAsStream(resourceName)) {
+            Files.copy(from, to.toPath());
+        }
+    }
+}

--- a/rider-core/src/test/resources/config/sample-dbunit.yml
+++ b/rider-core/src/test/resources/config/sample-dbunit.yml
@@ -2,6 +2,7 @@ cacheConnection: false
 cacheTableNames: false
 leakHunter: true
 raiseExceptionOnCleanUp: true
+expectedDbType: HSQLDB
 properties:
   batchedStatements:  true
   caseSensitiveTableNames: false


### PR DESCRIPTION
Add "expectedDbType" config option for DBUnit and dbunit.yml.

In the process of initialization, if the actual database type is different from the expected database type, exception will be thrown unless the expected database type is `UNKNOWN`. Default is `UNKNOWN`.

Close #227 .