### PR TITLE
Patch for using DB Rider with MS SQL Server

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
@@ -22,6 +22,9 @@ import org.dbunit.operation.*;
 
  UPDATE
  This strategy updates existing rows using data provided in the datasets. If dataset contain a row which is not present in the database (identified by its primary key) then exception is thrown.
+ 
+ IDENTITY_INSERT
+ This strategy disables the MS SQL Server automatic identifier generation for the execution of inserts. Use it if you need to define record ids in your datasets.
  */
 public enum SeedStrategy {
     CLEAN_INSERT(DatabaseOperation.CLEAN_INSERT),

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
@@ -4,6 +4,7 @@ package com.github.database.rider.core.api.dataset;
  * Created by pestano on 23/07/15.
  */
 
+import org.dbunit.ext.mssql.InsertIdentityOperation;
 import org.dbunit.operation.*;
 
 /**

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/SeedStrategy.java
@@ -28,7 +28,8 @@ public enum SeedStrategy {
     TRUNCATE_INSERT(new CompositeOperation(DatabaseOperation.TRUNCATE_TABLE, DatabaseOperation.INSERT)),
     INSERT(DatabaseOperation.INSERT),
     REFRESH(DatabaseOperation.REFRESH),
-    UPDATE(DatabaseOperation.UPDATE);
+    UPDATE(DatabaseOperation.UPDATE),
+    IDENTITY_INSERT(InsertIdentityOperation.CLEAN_INSERT);
 
     private final DatabaseOperation operation;
 

--- a/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
@@ -16,6 +16,7 @@ import org.testcontainers.containers.MSSQLServerContainer;
 
 import java.sql.*;
 
+import static com.github.database.rider.core.api.dataset.SeedStrategy.IDENTITY_INSERT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(JUnit4.class)
@@ -46,6 +47,14 @@ public class MsSQLDatabaseIt {
     @Test
     @DataSet(value = "datasets/yml/lowercaseUsers.yml")
     public void shouldSeedDataSet() {
+        User user = (User) EntityManagerProvider.em().createQuery("select u from User u where u.id = 1").getSingleResult();
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(1);
+    }
+	
+    @Test
+    @DataSet(value = "datasets/yml/lowercaseUsers.yml", strategy = IDENTITY_INSERT)
+    public void shouldSeedDataSetWithIdentityInsertStrategy() {
         User user = (User) EntityManagerProvider.em().createQuery("select u from User u where u.id = 1").getSingleResult();
         assertThat(user).isNotNull();
         assertThat(user.getId()).isEqualTo(1);

--- a/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
@@ -73,7 +73,7 @@ public class MsSQLDatabaseIt {
     @DBUnit(leakHunter = true, caseSensitiveTableNames = true, escapePattern = "\"?\"")
     public void shouldFindConnectionLeak() throws SQLException {
         exception.expect(LeakHunterException.class);
-        exception.expectMessage("Execution of method shouldFindConnectionLeak left 2 open connection(s).");
+        exception.expectMessage("Execution of method shouldFindConnectionLeak left 1 open connection(s).");
         createLeak();
     }
 

--- a/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/MsSQLDatabaseIt.java
@@ -73,7 +73,7 @@ public class MsSQLDatabaseIt {
     @DBUnit(leakHunter = true, caseSensitiveTableNames = true, escapePattern = "\"?\"")
     public void shouldFindConnectionLeak() throws SQLException {
         exception.expect(LeakHunterException.class);
-        exception.expectMessage("Execution of method shouldFindConnectionLeak left 1 open connection(s).");
+        exception.expectMessage("Execution of method shouldFindConnectionLeak left 2 open connection(s).");
         createLeak();
     }
 


### PR DESCRIPTION
Added IDENTITY_INSERT SeedStrategy to avoid following error:
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Cannot insert explicit value for identity column in table 'xxxxx' when IDENTITY_INSERT is set to OFF.