### PR TITLE
#365 Spring @Transactional tests is broken

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -99,7 +99,6 @@ public class DataSetExecutorImpl implements DataSetExecutor {
         if (dataSetConfig != null) {
             IDataSet resultingDataSet = null;
             try {
-                getRiderDataSource().setConnectionAutoCommit(true);
                 if (dataSetConfig.isDisableConstraints()) {
                     disableConstraints();
                 }
@@ -139,12 +138,6 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                     logDataSet(resultingDataSet, e);
                 }
                 throw new DataBaseSeedingException("Could not initialize dataset: " + dataSetConfig, e);
-            } finally {
-                try {
-                    getRiderDataSource().resetConnectionAutoCommit();
-                } catch (SQLException e) {
-                    log.error("Could not reset connection auto commit", e);
-                }
             }
         }
 


### PR DESCRIPTION
keeping default connection autoCommit configuration when creating a DataSet.

Tests are passing so I am assuming forcing autoCommit to true when creating the DataSet is not necessary.