### PR TITLE
Table ordering is not taken into account

### DIFF
--- a/rider-core/pom.xml
+++ b/rider-core/pom.xml
@@ -22,10 +22,6 @@
             		<groupId>postgresql</groupId>
             		<artifactId>postgresql</artifactId>
             	</exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -571,7 +571,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
     public void clearDatabase(DataSetConfig config) throws SQLException {
         try {
             disableConstraints();
-            Set<String> cleanupStatements = new HashSet<>();
+            List<String> cleanupStatements = new LinkedList<>();
             if (config != null && config.getTableOrdering() != null && config.getTableOrdering().length > 0) {
                 for (String table : config.getTableOrdering()) {
                     if (table.toUpperCase().contains(SEQUENCE_TABLE_NAME)) {


### PR DESCRIPTION
DataSetExecutorImpl#clearDatabase method does not take table ordering configuration into account as it puts all the delete statements in a HashSet, which is a Set implementation that does not guarantee any ordering.

Fixes https://github.com/database-rider/database-rider/issues/417