### PR TITLE
Execute statement with default options

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -413,9 +413,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
             try {
                 final Connection connection = getRiderDataSource().getDBUnitConnection().getConnection();
                 getRiderDataSource().setConnectionAutoCommit(false);
-                statement = connection.createStatement(
-                        ResultSet.TYPE_SCROLL_SENSITIVE,
-                        ResultSet.CONCUR_UPDATABLE);
+                statement = connection.createStatement();
                 for (String stm : statements) {
                     statement.addBatch(stm);
                 }


### PR DESCRIPTION
Create the SQL statement with default cursor & concurrency option in `executeStatements(String... statements)`.
This allows it to work with SQLite. Beside we don't use the returned ResultSet anyway.