### PR TITLE
Feature Request #567: allow configuration of DataSetProvider instance

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
@@ -25,7 +25,7 @@ public class DataSetConfig {
     private String[] executeStatementsAfter = {};
     private String[] executeScriptsBefore = {};
     private String[] executeScriptsAfter = {};
-    private Class<? extends DataSetProvider> provider;
+    private DataSetProvider provider;
     private String[] skipCleaningFor;
     private Class<? extends Replacer>[] replacers;
 
@@ -147,7 +147,18 @@ public class DataSetConfig {
 
     }
 
-    public DataSetConfig datasetProvider(Class<? extends DataSetProvider> provider) {
+    public DataSetConfig datasetProvider(Class<? extends DataSetProvider> providerClass) {
+        if (providerClass != null && !providerClass.isInterface()) {
+            try {
+                this.provider = providerClass.newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException("Could not instantiate provider: " + providerClass.getName(), e);
+            }
+        }
+        return this;
+    }
+
+    public DataSetConfig datasetProvider(DataSetProvider provider) {
         this.provider = provider;
         return this;
     }
@@ -200,7 +211,7 @@ public class DataSetConfig {
         return executorId;
     }
 
-    public Class<? extends DataSetProvider> getProvider() {
+    public DataSetProvider getProvider() {
         return provider;
     }
 
@@ -265,7 +276,7 @@ public class DataSetConfig {
             }
         }
         if(hasDataSetProvider()) {
-            sb.append("dataset provider: "+provider.getName()).append(", ");
+            sb.append("dataset provider: "+provider.getClass().getName()).append(", ");
         }
         if(sb.toString().contains(",")){
             sb.deleteCharAt(sb.lastIndexOf(","));
@@ -273,12 +284,8 @@ public class DataSetConfig {
         return sb.toString().trim();
     }
     
-    /**
-     * 
-     * @return true if dataset provider is not null and is not an interface (which means user has provided an implementation)
-     */
     public boolean hasDataSetProvider() {
-        return provider != null && !provider.isInterface();
+        return provider != null;
     }
 
     public boolean hasDataSets() {

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -123,7 +123,7 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                     } else {
                         resultingDataSet = loadDataSetFromDataSetProvider(dataSetConfig.getProvider());
                         if (resultingDataSet == null) {
-                            throw new RuntimeException("Provided dataset cannot be null. DataSet provider: " + dataSetConfig.getProvider().getName());
+                            throw new RuntimeException("Provided dataset cannot be null. DataSet provider: " + dataSetConfig.getProvider().getClass().getName());
                         }
                     }
                     resultingDataSet = performSequenceFiltering(dataSetConfig, resultingDataSet);
@@ -187,12 +187,11 @@ public class DataSetExecutorImpl implements DataSetExecutor {
         }
     }
 
-    private IDataSet loadDataSetFromDataSetProvider(Class<? extends DataSetProvider> provider) {
+    private IDataSet loadDataSetFromDataSetProvider(DataSetProvider provider) {
         try {
-            DataSetProvider dataSetProvider = provider.getDeclaredConstructor().newInstance();
-            return dataSetProvider.provide();
+            return provider.provide();
         } catch (Exception e) {
-            throw new RuntimeException("Could not load dataset from provider: " + provider.getName(), e);
+            throw new RuntimeException("Could not load dataset from provider: " + provider.getClass().getName(), e);
         }
     }
 

--- a/rider-core/src/test/java/com/github/database/rider/core/configuration/DataSetConfigTest.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/configuration/DataSetConfigTest.java
@@ -1,7 +1,10 @@
 package com.github.database.rider.core.configuration;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.DataSetProvider;
 import com.github.database.rider.core.api.dataset.SeedStrategy;
+import org.dbunit.dataset.DataSetException;
+import org.dbunit.dataset.IDataSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,6 +36,29 @@ public class DataSetConfigTest {
                 .hasFieldOrPropertyWithValue("cleanBefore", false)
                 .hasFieldOrPropertyWithValue("cleanAfter", true)
                 .hasFieldOrPropertyWithValue("transactional", true);
+        assertThat(dataSetConfig.hasDataSetProvider()).isFalse();
+    }
 
+    @Test
+    @DataSet(provider = CustomDataSetProvider.class)
+    public void shouldInstantiateConfiguredDataSetProvider() throws NoSuchMethodException {
+        Method method = getClass().getMethod("shouldInstantiateConfiguredDataSetProvider");
+        assertThat(method).isNotNull();
+        DataSet dataSet = method.getAnnotation(DataSet.class);
+        assertThat(dataSet).isNotNull();
+
+        DataSetConfig dataSetConfig = new DataSetConfig().from(dataSet);
+
+        assertThat(dataSetConfig).isNotNull();
+        assertThat(dataSetConfig.hasDataSetProvider()).isTrue();
+        assertThat(dataSetConfig.getProvider()).isInstanceOf(CustomDataSetProvider.class);
+    }
+
+}
+
+class CustomDataSetProvider implements DataSetProvider {
+    @Override
+    public IDataSet provide() throws DataSetException {
+        return null;
     }
 }


### PR DESCRIPTION
See motivation in https://github.com/database-rider/database-rider/issues/567.

Changes:
 
 * Overload datasetProvider() to allow configuration using either class or instance.
 * Moved instantiation of DataSetProvider class from DataSetExecutorImpl into DataSetConfig::datasetProvider().
 * Added corresponding unit test case.