### PR TITLE
Add SnakeYAML 2.x compatibility

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DBUnitConfig.java
@@ -11,7 +11,6 @@ import com.github.database.rider.core.replacers.Replacer;
 import com.github.database.rider.core.replacers.UnixTimestampReplacer;
 import org.dbunit.database.IMetadataHandler;
 import org.dbunit.dataset.datatype.IDataTypeFactory;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -125,7 +124,7 @@ public class DBUnitConfig {
         if (inputStream == null) {
             return null;
         }
-        DBUnitConfig configFromFile = new Yaml().loadAs(inputStream, DBUnitConfig.class);
+        DBUnitConfig configFromFile = SnakeYamlHelper.createYaml().loadAs(inputStream, DBUnitConfig.class);
         configFromFile.initDefaultProperties();
         configFromFile.initDefaultConnectionConfig();
         return configFromFile;

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/SnakeYamlHelper.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/SnakeYamlHelper.java
@@ -1,0 +1,73 @@
+package com.github.database.rider.core.configuration;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+/**
+ * A Helper to create {@link Yaml} instance that is pre-configured to not restrict types which can be instantiated
+ * during deserialization. Works with both SnakeYaml 1.x and 2.x.
+ * <p>
+ * SnakeYaml 2.0 solved the
+ * <a href="https://www.cve.org/CVERecord?id=CVE-2022-1471">unsafe deserialization vulnerability</a> by changing the
+ * default behavior of constructed {@link Yaml} instance to restrict types which can be instantiated during
+ * deserialization. This behavior made impossible to define custom DataSet replacers in YAML as they must be
+ * instantiated during deserialization. This helper uses reflection to conditionally configure {@link Yaml} instance
+ * to accept any types during deserialization if SnakeYaml 2.x is used.
+ */
+public class SnakeYamlHelper {
+
+    public static Yaml createYaml() {
+        LoaderOptions loaderOptions = createLoaderOptions();
+        return new Yaml(loaderOptions);
+    }
+
+    private static LoaderOptions createLoaderOptions() {
+        LoaderOptions loaderOptions = new LoaderOptions();
+
+        try {
+            // If Snakeyaml 2.x is used, loaderOptions.setTagInspector(tag -> true) must be called to allow
+            // to instantiate any classes during deserialization (e.g. properties.replacers in dbunit.yml).
+            // There is no such method in Snakeyaml 1.x, so the reflection is used to try to call the method
+            // to support both Snakeyaml 1.x and 2.x.
+            Class<?> tagInspectorClass = Class.forName("org.yaml.snakeyaml.inspector.TagInspector");
+            Method setTagInspector = loaderOptions.getClass().getMethod("setTagInspector", tagInspectorClass);
+            Object isGlobalTagAllowedLambda = createIsGlobalTagAllowedLambda(tagInspectorClass);
+            setTagInspector.invoke(loaderOptions, isGlobalTagAllowedLambda);
+        } catch (ClassNotFoundException e) {
+            // Do nothing as Snakeyaml 1.x is used that allows any classes to be created by default
+        } catch (Throwable e) {
+            throw new IllegalStateException("Unable to create SnakeYaml LoaderOptions", e);
+        }
+
+        return loaderOptions;
+    }
+
+    private static Object createIsGlobalTagAllowedLambda(Class<?> tagInspectorClass) throws Throwable {
+        MethodType methodType = MethodType.methodType(boolean.class, Tag.class);
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodHandle handle = lookup.findStatic(SnakeYamlHelper.class, "isGlobalTagAllowed", methodType);
+        CallSite callSite = LambdaMetafactory.metafactory(
+                lookup,
+                "isGlobalTagAllowed",
+                MethodType.methodType(tagInspectorClass),
+                methodType,
+                handle,
+                methodType
+        );
+        MethodHandle target = callSite.getTarget();
+        return target.invoke();
+    }
+
+    private static boolean isGlobalTagAllowed(Tag tag) {
+        return true;
+    }
+
+}


### PR DESCRIPTION
SnakeYaml 2.0 solved the unsafe deserialization vulnerability by changing the default behavior of constructed `Yaml` instance to restrict types which can be instantiated during deserialization.

This behavior made impossible to define custom DataSet replacers in YAML as they must be instantiated during deserialization.

E.g.
```
caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
properties:
  replacers: [!!my.package.WktReplacer {}]
```

Both `Orthography` enum and `WktReplacer` could not be instantiated during YAML deserialization.

This commit fixes this behavior by configuring SnakeYAML 2.x to use the old behavior (allow any class to be instantiated).

This is acceptable solution as `dbunit.yml` is loaded from the trusted source, so the mentioned vulnerability is not relevant here.

See:
* https://www.cve.org/CVERecord?id=CVE-2022-1471

Fixes #575