### PR TITLE
keeping table export ordering indicated in "includeTables"

### DIFF
--- a/rider-cdi/src/test/java/com/github/database/rider/cdi/ExportDataSetCDIIt.java
+++ b/rider-cdi/src/test/java/com/github/database/rider/cdi/ExportDataSetCDIIt.java
@@ -26,9 +26,7 @@ import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 @RunWith(CdiTestRunner.class)
 @DBUnitInterceptor
 public class ExportDataSetCDIIt {
-
 	private static final String NEW_LINE = System.getProperty("line.separator");
-
 
 	@Inject
     EntityManager em;
@@ -324,12 +322,31 @@ public class ExportDataSetCDIIt {
 		assertThat(dtdDataSet).exists();
 
 		assertThat(contentOf(dtdDataSet)).contains(
-				"<!ELEMENT dataset (\n" + "    TWEET*,\n" + "    USER*,\n" + "    FOLLOWER*)>\n" + "\n"
-						+ "<!ELEMENT TWEET EMPTY>\n" + "<!ATTLIST TWEET\n" + "    ID CDATA #REQUIRED\n"
-						+ "    CONTENT CDATA #IMPLIED\n" + "    DATE CDATA #IMPLIED\n" + "    LIKES CDATA #IMPLIED\n"
-						+ "    USER_ID CDATA #IMPLIED\n" + ">\n" + "\n" + "<!ELEMENT USER EMPTY>\n" + "<!ATTLIST USER\n"
-						+ "    ID CDATA #REQUIRED\n" + "    NAME CDATA #IMPLIED\n" + ">\n" + "\n" + "<!ELEMENT FOLLOWER EMPTY>\n"
-						+ "<!ATTLIST FOLLOWER\n" + "    ID CDATA #REQUIRED\n" + "    USER_ID CDATA #IMPLIED\n"
-						+ "    FOLLOWER_ID CDATA #IMPLIED\n" + ">\n" + "\n");
+				"<!ELEMENT dataset (\n" +
+						"    USER*,\n" +
+						"    FOLLOWER*,\n" +
+						"    TWEET*)>\n" +
+						"\n" +
+						"<!ELEMENT USER EMPTY>\n" +
+						"<!ATTLIST USER\n" +
+						"    ID CDATA #REQUIRED\n" +
+						"    NAME CDATA #IMPLIED\n" +
+						">\n" +
+						"\n" +
+						"<!ELEMENT FOLLOWER EMPTY>\n" +
+						"<!ATTLIST FOLLOWER\n" +
+						"    ID CDATA #REQUIRED\n" +
+						"    USER_ID CDATA #IMPLIED\n" +
+						"    FOLLOWER_ID CDATA #IMPLIED\n" +
+						">\n" +
+						"\n" +
+						"<!ELEMENT TWEET EMPTY>\n" +
+						"<!ATTLIST TWEET\n" +
+						"    ID CDATA #REQUIRED\n" +
+						"    CONTENT CDATA #IMPLIED\n" +
+						"    DATE CDATA #IMPLIED\n" +
+						"    LIKES CDATA #IMPLIED\n" +
+						"    USER_ID CDATA #IMPLIED\n" +
+						">");
 	}
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/exporter/DataSetExporter.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/exporter/DataSetExporter.java
@@ -25,7 +25,7 @@ import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -101,7 +101,7 @@ public class DataSetExporter {
         DatabaseConfig config = databaseConnection.getConfig();
         config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, new ForwardOnlyResultSetTableFactory());
 
-        Set<String> targetTables = new HashSet<>();
+        Set <String> targetTables = new LinkedHashSet<>();
 
         if (hasIncludes) {
             targetTables.addAll(Arrays.asList(dataSetExportConfig.getIncludeTables()));

--- a/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportDataSetIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/exporter/ExportDataSetIt.java
@@ -542,33 +542,33 @@ public class ExportDataSetIt {
       
       assertThat(dtdDataSet).exists();
       assertThat(contentOf(dtdDataSet)).
-              contains("<!ELEMENT dataset (\n" + 
-              		"    TWEET*,\n" + 
-              		"    USER*,\n" + 
-              		"    FOLLOWER*)>\n" + 
-              		"\n" + 
-              		"<!ELEMENT TWEET EMPTY>\n" + 
-              		"<!ATTLIST TWEET\n" + 
-              		"    ID CDATA #REQUIRED\n" + 
-              		"    CONTENT CDATA #IMPLIED\n" + 
-              		"    DATE CDATA #IMPLIED\n" + 
-              		"    LIKES CDATA #IMPLIED\n" + 
-              		"    TIMESTAMP CDATA #IMPLIED\n" + 
-              		"    USER_ID CDATA #IMPLIED\n" + 
-              		">\n" + 
-              		"\n" + 
-              		"<!ELEMENT USER EMPTY>\n" + 
-              		"<!ATTLIST USER\n" + 
-              		"    ID CDATA #REQUIRED\n" + 
-              		"    NAME CDATA #IMPLIED\n" + 
-              		">\n" + 
-              		"\n" + 
-              		"<!ELEMENT FOLLOWER EMPTY>\n" + 
+              contains("<!ELEMENT dataset (\n" +
+                    "    USER*,\n" +
+                    "    FOLLOWER*,\n" +
+              		"    TWEET*)>\n" +
+              		"\n" +
+                    "<!ELEMENT USER EMPTY>\n" +
+                    "<!ATTLIST USER\n" +
+                    "    ID CDATA #REQUIRED\n" +
+                    "    NAME CDATA #IMPLIED\n" +
+              		">\n" +
+              		"\n" +
+              		"<!ELEMENT FOLLOWER EMPTY>\n" +
               		"<!ATTLIST FOLLOWER\n" + 
               		"    ID CDATA #REQUIRED\n" + 
               		"    USER_ID CDATA #IMPLIED\n" + 
-              		"    FOLLOWER_ID CDATA #IMPLIED\n" + 
-              		">\n" + 
+              		"    FOLLOWER_ID CDATA #IMPLIED\n" + ">" +
+                    "\n" +
+                    "\n" +
+                    "<!ELEMENT TWEET EMPTY>\n" +
+                    "<!ATTLIST TWEET\n" +
+                    "    ID CDATA #REQUIRED\n" +
+                    "    CONTENT CDATA #IMPLIED\n" +
+                    "    DATE CDATA #IMPLIED\n" +
+                    "    LIKES CDATA #IMPLIED\n" +
+                    "    TIMESTAMP CDATA #IMPLIED\n" +
+                    "    USER_ID CDATA #IMPLIED\n" +
+                    ">\n" +
               		"\n");
     }
     


### PR DESCRIPTION
The tables exported with ExportDataSet have no ordining.
These bothe ExportDataSet instructions are generateing the same export files:
-   @ExportDataSet(includeTables = {"PRODUCT","SUBPRODUCT"}, dependentTables = true)
-   @ExportDataSet(includeTables = {"SUBPRODUCT","PRODUCT"}, dependentTables = true)


Changing the code from HashMap to LinkedHashMap is givin the developer the control of the table ordering.