### PR TITLE
fix dataset annotaiton attribute text alignment

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSet.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/DataSet.java
@@ -99,18 +99,18 @@ public @interface DataSet {
    */
   Class<? extends DataSetProvider> provider() default DataSetProvider.class;
 
-    /**
-     * By default ALL tables are cleaned when <code>cleanBefore</code> or <code>cleanAfter</code> is set to <code>true</code>.
-     *
-     * Allows user to provide tables which will NOT be cleaned in <code>cleanBefore</code> and <code>cleanAfter</code>.
-     *
-     * @return list of table names to skip the cleaning in <code>cleanBefore</code> and/or <code>cleanAfter</code>. If empty all tables will be cleaned when cleanBefore() or cleanAfter() is set to <code>true</code>
-     */
+  /**
+   * By default ALL tables are cleaned when <code>cleanBefore</code> or <code>cleanAfter</code> is set to <code>true</code>.
+   *
+   * Allows user to provide tables which will NOT be cleaned in <code>cleanBefore</code> and <code>cleanAfter</code>.
+   *
+   * @return list of table names to skip the cleaning in <code>cleanBefore</code> and/or <code>cleanAfter</code>. If empty all tables will be cleaned when cleanBefore() or cleanAfter() is set to <code>true</code>
+   */
   String[] skipCleaningFor() default {};
 
-    /**
-     * @return implementations of {@link Replacer} to be used as dataset replacement during seeding database.
-     * Note that DataSet level replacer will <b>override</b> global level replacers.
-     */
-    Class<? extends Replacer>[] replacers() default {};
+  /**
+   * @return implementations of {@link Replacer} to be used as dataset replacement during seeding database.
+   * Note that DataSet level replacer will <b>override</b> global level replacers.
+   */
+  Class<? extends Replacer>[] replacers() default {};
 }


### PR DESCRIPTION
The text alignment of the replacers attribute in the dataset annotation is incorrect. While this may seem like a minor issue, misaligned text depth can cause confusion, making it appear as though it is a sub-attribute of the preceding attribute. To ensure clarity and consistency, I am requesting a pull request to display it at the same attribute depth.

before
![image](https://github.com/database-rider/database-rider/assets/31757314/e07d885b-f0cb-4e37-a8d2-12ca30e5947c)

after
![image](https://github.com/database-rider/database-rider/assets/31757314/7a7f9389-281a-41f6-b02a-5bc8c4a2472b)
