### PR TITLE
add dataset value attribute and provider attribute duplication use log

### DIFF
--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -119,6 +119,9 @@ public class DataSetExecutorImpl implements DataSetExecutor {
                 }
                 if (dataSetConfig.hasDataSets() || dataSetConfig.hasDataSetProvider()) {
                     if (dataSetConfig.hasDataSets()) {
+                        if (dataSetConfig.hasDataSetProvider()) {
+                            log.warn("The value attribute and the provider attribute of DataSet Annotation cannot be used together. The provider attribute will not be applied.");
+                        }
                         resultingDataSet = loadDataSets(dataSetConfig.getDatasets());
                     } else {
                         resultingDataSet = loadDataSetFromDataSetProvider(dataSetConfig.getProvider());


### PR DESCRIPTION
Hi, @rmpestano 

Recently, I have been working on a project using database-rider, and I encountered a situation where I needed to use both the value and provider attributes of the @DataSet annotation simultaneously. When I used them together, the execution completed without any logs, leading me to believe that everything was applied correctly. However, upon further inspection, I realized that neither attribute was actually applied.

I had to debug the internal logic step by step to discover that both attributes were not being applied. Some of my team members also went through the same trouble as I did.

Therefore, I believe that logging the following message when both the value and provider attributes of the @DataSet annotation are used together would save others from experiencing the same issue. I am sending a PR with this change.

Have a great day.

before
![image](https://github.com/database-rider/database-rider/assets/31757314/c1919c7b-c0f0-4ad1-9258-5adeadc0b053)

after
![image](https://github.com/database-rider/database-rider/assets/31757314/41f4e9b3-054a-4e68-b792-98b23750de9f)
