### PR TITLE
Respect @DBRider in junit5 @BeforeAll, @BeforeEach, @AfterAll, @AfterEach methods

### DIFF
--- a/rider-examples/spring-boot-dbunit-sample/src/test/java/com/github/database/rider/springboot/LeakingConnectionsTest.java
+++ b/rider-examples/spring-boot-dbunit-sample/src/test/java/com/github/database/rider/springboot/LeakingConnectionsTest.java
@@ -57,7 +57,7 @@ public class LeakingConnectionsTest {
             config.setJdbcUrl("jdbc:hsqldb:mem:leak;DB_CLOSE_DELAY=-1");
             config.setUsername("sa");
             config.setPassword("");
-            config.setMaximumPoolSize(2);
+            config.setMaximumPoolSize(3);
             config.setConnectionTimeout(5000);
             return new WrappingDataSource(new HikariDataSource(config));
         }

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/integration/Micronaut.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/integration/Micronaut.java
@@ -21,7 +21,11 @@ public class Micronaut {
 
     public static ConnectionHolder getConnectionFromMicronautContext(ExtensionContext extensionContext, String executorId) {
         String configuredDataSourceBeanName = getConfiguredDataSourceBeanName(extensionContext);
-        DataSource dataSource = getDataSourceFromMicronautContext(extensionContext, configuredDataSourceBeanName);
+        return getConnectionFromMicronautContext(extensionContext, executorId, configuredDataSourceBeanName);
+    }
+
+    public static ConnectionHolder getConnectionFromMicronautContext(ExtensionContext extensionContext, String executorId, String dataSourceBeanName) {
+        DataSource dataSource = getDataSourceFromMicronautContext(extensionContext, dataSourceBeanName);
         return getConnectionHolder(executorId, dataSource);
     }
 

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/integration/Spring.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/integration/Spring.java
@@ -30,6 +30,11 @@ public class Spring {
         return getConnectionHolder(executorId, dataSource);
     }
 
+    public static ConnectionHolder getConnectionFromSpringContext(ExtensionContext extensionContext, String executorId, String dataSourceBeanName) {
+        DataSource dataSource = getDataSourceFromSpringContext(extensionContext, dataSourceBeanName);
+        return getConnectionHolder(executorId, dataSource);
+    }
+
     private static DataSource getDataSourceFromSpringContext(ExtensionContext extensionContext, String beanName) {
         ApplicationContext context = SpringExtension.getApplicationContext(extensionContext);
         return beanName.isEmpty() ? context.getBean(DataSource.class) : context.getBean(beanName, DataSource.class);


### PR DESCRIPTION
Current implementation doesn't support @DbRider in callback methods. It makes impossible to set up test data into several independent datasources.  This pr makes working such approach:

```java
    @BeforeAll
    @DBRider(dataSourceBeanName = "firstDataSource")
    @DataSet(value = "test-data-1.xml")
    static void setUpDataInFirstDb() {
    }

    @BeforeAll
    @DBRider(dataSourceBeanName = "secondDataSource")
    @DataSet(value = "test-data-2.xml", disableConstraints = true)
    static void setUpDataInSecondDb() {
    }
```