### PR TITLE
refs #610 fix annotation support for parent classes hierarchy

### DIFF
--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
@@ -106,7 +106,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
     private Set<Method> findCallbackMethods(Class testClass, Class callback) {
         final Set<Method> methods = new HashSet<>();
         Stream.of(testClass.getSuperclass()
-                        .getDeclaredMethods(), testClass.getDeclaredMethods())
+                        .getMethods(), testClass.getMethods())
                 .flatMap(Stream::of)
                 .filter(m -> m.getAnnotation(callback) != null)
                 .forEach(m -> methods.add((Method) m)); //do not use Collectors.toSet here: stream incompatible types

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/BaseLifecycleHooks.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/BaseLifecycleHooks.java
@@ -1,41 +1,4 @@
 package com.github.database.rider.junit5;
 
-import com.github.database.rider.core.api.configuration.DBUnit;
-import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.model.Tweet;
-import com.github.database.rider.junit5.model.User;
-import com.github.database.rider.junit5.util.EntityManagerProvider;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@DBUnit(url = "jdbc:hsqldb:mem:junit5;DB_CLOSE_DELAY=-1", driver = "org.hsqldb.jdbcDriver", user = "sa")
-public abstract class BaseLifecycleHooks {
-
-    @BeforeAll
-    @DataSet(value = "usersAndTweetsBeforeAll.yml", disableConstraints = true)
-    public static void loadDataSetBeforeAll() {
-    }
-
-    @BeforeEach
-    @DataSet(value = "tweetBeforeEachOnSuperClass.yml", disableConstraints = true)
-    public void loadDataSetBeforeEach() {
-    }
-
-    @AfterEach
-    @ExpectedDataSet(value = "expectedTweetsAfterEachSuperclass.yml", orderBy = "CONTENT")
-    public void verifyInvariantsAfterEach() {
-    }
-
-    @AfterAll
-    @DataSet(value = "usersAndTweetsAfterAll.yml", disableConstraints = true)
-    public static void loadDataSetAfterAll() {
-    }
-
+public abstract class BaseLifecycleHooks extends ParentBaseLifecycleHooks {
 }

--- a/rider-junit5/src/test/java/com/github/database/rider/junit5/ParentBaseLifecycleHooks.java
+++ b/rider-junit5/src/test/java/com/github/database/rider/junit5/ParentBaseLifecycleHooks.java
@@ -1,0 +1,34 @@
+package com.github.database.rider.junit5;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+@DBUnit(url = "jdbc:hsqldb:mem:junit5;DB_CLOSE_DELAY=-1", driver = "org.hsqldb.jdbcDriver", user = "sa")
+public abstract class ParentBaseLifecycleHooks {
+
+    @BeforeAll
+    @DataSet(value = "usersAndTweetsBeforeAll.yml", disableConstraints = true)
+    public static void loadDataSetBeforeAll() {
+    }
+
+    @BeforeEach
+    @DataSet(value = "tweetBeforeEachOnSuperClass.yml", disableConstraints = true)
+    public void loadDataSetBeforeEach() {
+    }
+
+    @AfterEach
+    @ExpectedDataSet(value = "expectedTweetsAfterEachSuperclass.yml", orderBy = "CONTENT")
+    public void verifyInvariantsAfterEach() {
+    }
+
+    @AfterAll
+    @DataSet(value = "usersAndTweetsAfterAll.yml", disableConstraints = true)
+    public static void loadDataSetAfterAll() {
+    }
+
+}


### PR DESCRIPTION
The reason you have fixed it with `getDeclaredMethods` is that you thought you would detect private methods, but private classes cannot be annotated with `@BeforeXXX` or `@AfterXXX`.

Further I wasn't able to run all test in one go, all the errors seems unrelated, especially the IT ones. I have only tried a few running on their own and then it works, but running the test on the complete project it fails.