### PR TITLE
Add support for Micronaut 3

### DIFF
--- a/rider-junit5/pom.xml
+++ b/rider-junit5/pom.xml
@@ -91,13 +91,19 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-inject</artifactId>
-            <version>1.3.6</version>
+            <version>3.10.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-tx</artifactId>
+            <version>3.10.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.micronaut.test</groupId>
             <artifactId>micronaut-test-junit5</artifactId>
-            <version>1.2.0</version>
+            <version>3.9.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/jdbc/ConnectionManager.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/jdbc/ConnectionManager.java
@@ -7,6 +7,7 @@ import com.github.database.rider.core.dataset.DataSetExecutorImpl;
 import com.github.database.rider.junit5.api.DBRider;
 import com.github.database.rider.junit5.integration.Micronaut;
 import com.github.database.rider.junit5.integration.Spring;
+import io.micronaut.transaction.jdbc.DelegatingDataSource;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.AnnotationUtils;
 
@@ -63,7 +64,8 @@ public final class ConnectionManager {
             if (isCachedConnection(dataSetExecutor)) {
                 return new ConnectionHolderImpl(dataSetExecutor.getRiderDataSource().getDBUnitConnection().getConnection());
             } else {
-                return new ConnectionHolderImpl(dataSource.getConnection());
+                DataSource unwrappedDataSource = DelegatingDataSource.unwrapDataSource(dataSource);
+                return new ConnectionHolderImpl(unwrappedDataSource.getConnection());
             }
         } catch (SQLException e) {
             throw new RuntimeException("Could not get connection from DataSource.");


### PR DESCRIPTION
This resolves the issue where db rider fails due to connection needing to be unwrapped before usage.

Solution blatantly stolen from https://github.com/database-rider/database-rider/issues/577

Remember that this is only compatible with micronaut 3 - to get this working with Micronaut 4 we need to change import from 
`import io.micronaut.transaction.jdbc.DelegatingDataSource `

to
`import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;`
