### PR TITLE
add timeout in ExpectedDataSet.java

### DIFF
--- a/rider-cdi/src/main/java/com/github/database/rider/cdi/DBUnitInterceptorImpl.java
+++ b/rider-cdi/src/main/java/com/github/database/rider/cdi/DBUnitInterceptorImpl.java
@@ -94,7 +94,8 @@ public class DBUnitInterceptorImpl implements Serializable {
                     dataSetProcessor.compareCurrentDataSetWith(
                             new DataSetConfig(expectedDataSet.value())
                                     .datasetProvider(expectedDataSet.provider())
-                                    .disableConstraints(true),
+                                    .disableConstraints(true)
+                                    .timeout(expectedDataSet.timeout()),
                             expectedDataSet.ignoreCols(),
                             expectedDataSet.replacers(),
                             expectedDataSet.orderBy(),
@@ -140,7 +141,7 @@ public class DBUnitInterceptorImpl implements Serializable {
                 proceed = invocationContext.proceed();
                 if (expectedDataSet != null) {
                     dataSetProcessor.compareCurrentDataSetWith(
-                            new DataSetConfig(expectedDataSet.value()).disableConstraints(true),
+                            new DataSetConfig(expectedDataSet.value()).disableConstraints(true).timeout(expectedDataSet.timeout()),
                             expectedDataSet.ignoreCols(), expectedDataSet.replacers(), expectedDataSet.ignoreCols(), expectedDataSet.compareOperation());
                 }
             } finally {

--- a/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/RiderRunner.java
@@ -141,7 +141,7 @@ public class RiderRunner {
 
         if (expectedDataSet != null) {
             riderTestContext.getDataSetExecutor()
-                    .compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value())
+                    .compareCurrentDataSetWith(new DataSetConfig(expectedDataSet.value()).timeout(expectedDataSet.timeout())
                                     .disableConstraints(true).datasetProvider(expectedDataSet.provider()),
                             expectedDataSet.ignoreCols(),
                             expectedDataSet.replacers(),

--- a/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ExpectedDataSet.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/api/dataset/ExpectedDataSet.java
@@ -43,4 +43,9 @@ public @interface ExpectedDataSet {
    * @return a dataset provider implementation responsible for generating the expected dataset programatically instead of providing an external file defining the dataset.
    */
   Class<? extends DataSetProvider> provider() default DataSetProvider.class;
+
+  /**
+   * @return timeout (in ms)
+   */
+  int timeout() default 0;
 }

--- a/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/configuration/DataSetConfig.java
@@ -28,12 +28,18 @@ public class DataSetConfig {
     private DataSetProvider provider;
     private String[] skipCleaningFor;
     private Class<? extends Replacer>[] replacers;
+    private int timeout = 0;
 
     public DataSetConfig() {
     }
 
     public DataSetConfig(String... datasets) {
         this.datasets = datasets;
+    }
+
+    public DataSetConfig timeout(int timeout) {
+        this.timeout = timeout;
+        return this;
     }
 
     public DataSetConfig name(String... datasets) {
@@ -161,6 +167,10 @@ public class DataSetConfig {
     public DataSetConfig datasetProvider(DataSetProvider provider) {
         this.provider = provider;
         return this;
+    }
+
+    public int getTimeout() {
+        return timeout;
     }
 
     public String[] getDatasets() {

--- a/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
+++ b/rider-core/src/main/java/com/github/database/rider/core/dataset/DataSetExecutorImpl.java
@@ -805,11 +805,9 @@ public class DataSetExecutorImpl implements DataSetExecutor {
     @Override
     public void compareCurrentDataSetWith(DataSetConfig expectedDataSetConfig, String[] excludeCols,
                                           Class<? extends Replacer>[] replacers, String[] orderBy, CompareOperation compareOperation) throws DatabaseUnitException {
-        IDataSet current = null;
         IDataSet expected = null;
         List<Replacer> expectedDataSetReplacers = getReplacerInstances(replacers);
         try {
-            current = getRiderDataSource().getDBUnitConnection().createDataSet();
             if (expectedDataSetConfig.hasDataSetProvider()) {
                 expected = loadDataSetFromDataSetProvider(expectedDataSetConfig.getProvider());
             } else if (expectedDataSetConfig.hasDataSets()) {
@@ -829,15 +827,34 @@ public class DataSetExecutorImpl implements DataSetExecutor {
             throw new RuntimeException("Could not extract dataset table names.", e);
         }
 
-        switch (compareOperation) {
-            case PROLOG:
-                PrologAssert.compareProlog(current, expected, tableNames, dbUnitConfig.getPrologTimeout());
-                break;
-            case EQUALS:
-            case CONTAINS:
-                compareClassic(excludeCols, orderBy, compareOperation, current, expected, tableNames);
-                break;
-        }
+        final long eta = System.currentTimeMillis() + expectedDataSetConfig.getTimeout();
+        boolean repeat;
+        do {
+            try {
+                IDataSet current = null;
+                try {
+                    current = getRiderDataSource().getDBUnitConnection().createDataSet();
+                } catch (Exception e) {
+                    throw new RuntimeException("Could not create dataset to compare.", e);
+                }
+                switch (compareOperation) {
+                    case PROLOG:
+                        PrologAssert.compareProlog(current, expected, tableNames, dbUnitConfig.getPrologTimeout());
+                        break;
+                    case EQUALS:
+                    case CONTAINS:
+                        compareClassic(excludeCols, orderBy, compareOperation, current, expected, tableNames);
+                        break;
+                }
+                repeat = false;
+            } catch (AssertionError e) {
+                if (System.currentTimeMillis() < eta) {
+                    repeat = true;
+                } else {
+                    throw e;
+                }
+            }
+        } while (repeat);
     }
 
     private void compareClassic(String[] excludeCols, String[] orderBy, CompareOperation compareOperation, IDataSet current, IDataSet expected, String[] tableNames) throws DatabaseUnitException {

--- a/rider-core/src/test/java/com/github/database/rider/core/ExpectedDataSetIt.java
+++ b/rider-core/src/test/java/com/github/database/rider/core/ExpectedDataSetIt.java
@@ -339,4 +339,26 @@ public class ExpectedDataSetIt {
         emProvider.tx().commit();
     }
 
+    @Test
+    @DataSet(value = "yml/otherUser.yml", cleanBefore = true, cleanAfter = true)
+    @ExpectedDataSet(value = "yml/user.yml", timeout = 1000)
+    public void shouldMatchUpdatedInitialDatasetInOtherThread() {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                emProvider.tx().begin();
+                User user = emProvider.getEm().find(User.class, 2L);
+                user.setName("@dbunit");
+                emProvider.getEm().merge(user);
+                emProvider.tx().commit();
+            }
+        }).start();
+
+    }
+
 }

--- a/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
+++ b/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java
@@ -255,7 +255,7 @@ public class DBUnitExtension implements BeforeTestExecutionCallback, AfterTestEx
         dataSetExecutor.setDBUnitConfig(dbUnitConfig);
         dataSetExecutor = resetExecutorConnectionIfNeeded(extensionContext, callbackAnnotation, dbUnitConfig, dataSetExecutor);
         dataSetExecutor.compareCurrentDataSetWith(
-                new DataSetConfig(expectedDataSet.value()).disableConstraints(true).datasetProvider(expectedDataSet.provider()),
+                new DataSetConfig(expectedDataSet.value()).disableConstraints(true).datasetProvider(expectedDataSet.provider()).timeout(expectedDataSet.timeout()),
                 expectedDataSet.ignoreCols(),
                 expectedDataSet.replacers(),
                 expectedDataSet.orderBy(),


### PR DESCRIPTION
now we can use dbrider in asynchronous applications:

```java
    @Test
    @DataSet(value = "yml/otherUser.yml", cleanBefore = true, cleanAfter = true)
    @ExpectedDataSet(value = "yml/user.yml", timeout = 1000)
    public void shouldMatchUpdatedInitialDatasetInOtherThread() {
        new Thread(new Runnable() {
            @Override
            public void run() {
                try {
                    Thread.sleep(100);
                } catch (InterruptedException e) {
                    throw new RuntimeException(e);
                }
                emProvider.tx().begin();
                User user = emProvider.getEm().find(User.class, 2L);
                user.setName("@dbunit");
                emProvider.getEm().merge(user);
                emProvider.tx().commit();
            }
        }).start();

    }
```